### PR TITLE
Introduce ServiceDeliveryType to distinguish between different responses

### DIFF
--- a/Sources/OJP/Models/OJPv2.swift
+++ b/Sources/OJP/Models/OJPv2.swift
@@ -55,6 +55,65 @@ public struct OJPv2: Codable {
     public struct ServiceDelivery: Codable {
         public let responseTimestamp: String
         public let producerRef: String
+        public let delivery: ServiceDeliveryType
+
+        public enum CodingKeys: String, CodingKey {
+            case responseTimestamp = "siri:ResponseTimestamp"
+            case producerRef = "siri:ProducerRef"
+        }
+
+        public init(from decoder: any Decoder) throws {
+            delivery = try ServiceDeliveryType(from: decoder)
+
+            let container = try decoder.container(keyedBy: StrippedPrefixCodingKey.self)
+            responseTimestamp = try container.decode(String.self, forKey: StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.responseTimestamp))
+            producerRef = try container.decode(String.self, forKey: StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.producerRef))
+        }
+    }
+
+    public enum ServiceDeliveryType: Codable {
+        case stopEvent(OJPv2.StopEventServiceDelivery)
+        case locationInformation(OJPv2.LocationInformationDelivery)
+
+        enum CodingKeys: String, CodingKey {
+            case locationInformation = "OJPLocationInformationDelivery"
+            case stopEvent = "OJPStopEventRequest"
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: StrippedPrefixCodingKey.self)
+            if container.contains(StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.locationInformation)) {
+                self = try .locationInformation(
+                    container.decode(
+                        LocationInformationDelivery.self,
+                        forKey: StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.locationInformation)
+                    )
+                )
+            } else {
+                throw OJPError.notImplemented
+            }
+        }
+    }
+
+    public struct StopEventServiceDelivery: Codable {
+        public let responseTimestamp: String
+        public let producerRef: String
+        public let stopEventDelivery: StopEventDelivery
+
+        public enum CodingKeys: String, CodingKey {
+            case responseTimestamp = "siri:ResponseTimestamp"
+            case producerRef = "siri:ProducerRef"
+            case stopEventDelivery = "OJPStopEventDelivery"
+        }
+    }
+
+    public struct StopEventDelivery: Codable {
+        let places: [Place]
+    }
+
+    public struct LocationInformationServiceDelivery: Codable {
+        public let responseTimestamp: String
+        public let producerRef: String
         public let locationInformationDelivery: LocationInformationDelivery
 
         public enum CodingKeys: String, CodingKey {
@@ -89,7 +148,6 @@ public struct OJPv2: Codable {
 
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: StrippedPrefixCodingKey.self)
-
             responseTimestamp = try container.decode(String.self, forKey: StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.responseTimestamp))
             requestMessageRef = try container.decode(String.self, forKey: StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.requestMessageRef))
             defaultLanguage = try container.decode(String.self, forKey: StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.defaultLanguage))

--- a/Sources/OJP/OJP.swift
+++ b/Sources/OJP/OJP.swift
@@ -49,9 +49,13 @@ public class OJP {
     public func nearbyStations(from point: (long: Double, lat: Double)) async throws -> [OJPv2.PlaceResult] {
         let ojp = OJPHelpers.LocationInformationRequest.initWithBoxCoordsWidthHeight(centerLongitude: point.long, centerLatitude: point.lat, boxWidth: 500.0)
 
-        let placeResults = try await request(with: ojp).serviceDelivery.locationInformationDelivery.placeResults
+        let serviceDelivery = try await request(with: ojp).serviceDelivery
 
-        return OJPHelpers.LocationInformationRequest.placeResultsSorted(from: point, placeResults: placeResults)
+        guard case let .locationInformation(locationInformationDelivery) = serviceDelivery.delivery else {
+            throw OJPError.unexpectedEmpty
+        }
+
+        return OJPHelpers.LocationInformationRequest.placeResultsSorted(from: point, placeResults: locationInformationDelivery.placeResults)
     }
 
     public func stations(from _: String, count _: Int) async throws -> [OJPv2.PlaceResult] {

--- a/Tests/OJPTests/OjpSDKTests.swift
+++ b/Tests/OJPTests/OjpSDKTests.swift
@@ -64,9 +64,13 @@ final class OjpSDKTests: XCTestCase {
 
         if let xmlString = String(data: data, encoding: .utf8) {
             print(xmlString)
-            let lir = try OJPDecoder.response(data).serviceDelivery.locationInformationDelivery
+            let serivceDelivery = try OJPDecoder.response(data).serviceDelivery
+            guard case let .locationInformation(locationInformation) = serivceDelivery.delivery else {
+                XCTFail()
+                return
+            }
             print("places:")
-            for placeResult in lir.placeResults {
+            for placeResult in locationInformation.placeResults {
                 print(placeResult.place.name.text)
             }
         }
@@ -96,8 +100,11 @@ final class OjpSDKTests: XCTestCase {
         if let xmlString = String(data: data, encoding: .utf8) {
             print(xmlString)
         }
-        let lir = try OJPDecoder.response(data).serviceDelivery.locationInformationDelivery
-        XCTAssert(lir.placeResults.count == 26)
+        guard case let .locationInformation(locationInformation) = try OJPDecoder.response(data).serviceDelivery.delivery else {
+            XCTFail()
+            return
+        }
+        XCTAssert(locationInformation.placeResults.count == 26)
     }
 
     func testFetchNearbyStations() async throws {


### PR DESCRIPTION
Inside of the `<ServiceDelivery>` Element we get different children types depending on the request (eg. `<OJPLocationInformationDelivery>` or `<OJPStopEventDelivery>`).

This proposal uses an enum with associated types to distinguish between those responses