### PR TITLE
Readme + RequestorRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ https://github.com/openTdataCH/ojp-ios.git
 ## Usage
 
 ### Initializing
+TBA
 - endpoints configuration
-- requestor Ref
-- authBearerKey - where to get it from
+- requesterReference
+- authBearerToken - where to get it from
 
 ```
 import OJP
 
-let ojpSdk = OJP(loadingStrategy: .http(.init(apiEndPoint: URL(string: "your api endpoint")!, requestReference: "your request reference", authBearerToken: "your token")))
+let ojpSdk = OJP(loadingStrategy: .http(.init(apiEndPoint: URL(string: "your api endpoint")!, requesterReference: "your request reference", authBearerToken: "your token")))
         
 
 ```

--- a/README.md
+++ b/README.md
@@ -17,25 +17,54 @@ Event Request](https://opentransportdata.swiss/en/cookbook/ojp-stopeventservice/
 
 ## Requirements
 
-TBA 
-- iOS versions supported
-- any other dependencies
+- Compatible with: iOS 15+ or macOS 14+
 
 ## Installation
 
-TBA 
-- screenshot with Swift PackageManager ?
+- The SDK can be integrated into your Xcode project using the Swift Package Manager. To do so, just add the package by using the following url
+```
+https://github.com/openTdataCH/ojp-ios.git
+```
 
 ## Usage
 
-TBA
-
 ### Initializing
 - endpoints configuration
-- token - where to get it from
+- requestor Ref
+- authBearerKey - where to get it from
+
+```
+import OJP
+
+let ojpSdk = OJP(loadingStrategy: .http(.init(apiEndPoint: "your endpoint", requestorRef: "your Ref", authBearerKey: "your bearer key")))        
+
+```
 
 ### Basic Usage
-- code sample to be used
+
+Get a list of Stations from a keyword.
+
+```
+import OJP
+
+
+let stations = try await ojpSdk.stations(by: "Bern", limit: 10)
+                   
+
+```
+
+
+Get a list of Stations around a place with longitude and latitude
+
+```
+import OJP
+
+
+let nearbyStations = try await ojpSdk.nearbyStations(from: Point(long: 9.44, lat: 5.66))                   
+
+```
+
+
 - link to a sample app repo (later)
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Overview
 
 This SDK is targeting iOS applications seeking to integrate [Open Journey Planner(OJP) APIs](https://opentdatach.github.io/ojp-ios/documentation/ojp/) to support distributed journey planning according to the European (CEN) Technical Specification entitled “Intelligent transport systems – Public transport – Open API for distributed journey planning”
+Currently the SDK is under construction, so there is not yet a stable version and the APIs may change.
 
 ### Features
 
@@ -36,7 +37,7 @@ https://github.com/openTdataCH/ojp-ios.git
 ```
 import OJP
 
-let ojpSdk = OJP(loadingStrategy: .http(.init(apiEndPoint: "your end_point", requestReference: "your request reference", authBearerKey:"your token")))
+let ojpSdk = OJP(loadingStrategy: .http(.init(apiEndPoint: URL(string: "your api endpoint")!, requestReference: "your request reference", authBearerToken: "your token")))
         
 
 ```

--- a/README.md
+++ b/README.md
@@ -36,31 +36,32 @@ https://github.com/openTdataCH/ojp-ios.git
 ```
 import OJP
 
-let ojpSdk = OJP(loadingStrategy: .http(.init(apiEndPoint: "your endpoint", requestorRef: "your Ref", authBearerKey: "your bearer key")))        
+let ojpSdk = OJP(loadingStrategy: .http(.init(apiEndPoint: "your end_point", requestReference: "your request reference", authBearerKey:"your token")))
+        
 
 ```
 
 ### Basic Usage
 
-Get a list of Stations from a keyword.
+Get a list of Locations from a keyword.
 
 ```
 import OJP
 
 
-let stations = try await ojpSdk.stations(by: "Bern", limit: 10)
+let searchedLocations = try await ojpSdk.requestLocations(from: "Bern")
                    
 
 ```
 
 
-Get a list of Stations around a place with longitude and latitude
+Get a list of Locations around a place with longitude and latitude
 
 ```
 import OJP
 
-
-let nearbyStations = try await ojpSdk.nearbyStations(from: Point(long: 9.44, lat: 5.66))                   
+let nearbyLocations = try await ojpSdk.requestLocations(from: Point(long: 5.6, lat: 2.3))
+                           
 
 ```
 

--- a/Sources/OJP/APIConfiguration.swift
+++ b/Sources/OJP/APIConfiguration.swift
@@ -13,7 +13,7 @@ public struct APIConfiguration {
     public let requestReference: String
     public let authBearerToken: String?
     public let additionalHeaders: [(key: String, value: String)]?
-    
+
     /// Configuration for the API
     /// - Parameters:
     ///   - apiEndPoint: the URL that points to the backend API

--- a/Sources/OJP/APIConfiguration.swift
+++ b/Sources/OJP/APIConfiguration.swift
@@ -11,21 +11,27 @@ import Foundation
 public struct APIConfiguration {
     public let apiEndPoint: URL
     public let requestReference: String
-    public let accessToken: String?
+    public let authBearerToken: String?
     public let additionalHeaders: [(key: String, value: String)]?
-
-    public init(apiEndPoint: URL, requestReference: String, authBearerKey: String? = nil, additionalHeaders: [(key: String, value: String)]? = nil) {
+    
+    /// Configuration for the API
+    /// - Parameters:
+    ///   - apiEndPoint: the URL that points to the backend API
+    ///   - requestReference: a reference that will be added to the XML repreresenting your client
+    ///   - authBearerToken: a Bearer token, it's send in this manner: Authorization: Bearer <your token>
+    ///   - additionalHeaders: some HTTP custom headers
+    public init(apiEndPoint: URL, requestReference: String, authBearerToken: String? = nil, additionalHeaders: [(key: String, value: String)]? = nil) {
         self.apiEndPoint = apiEndPoint
-        self.requestReference = "\(requestReference)_\(OJP_SDK_Version)"
-        accessToken = authBearerKey
+        self.requestReference = "\(requestReference)_\(OJP_SDK_Name)_\(OJP_SDK_Version)"
+        self.authBearerToken = authBearerToken
         self.additionalHeaders = additionalHeaders
     }
 
     /// TEST environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    static let test = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-test")!, requestReference: "OJP_Demo_iOS", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    static let test = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-test")!, requestReference: "OJP_Demo_iOS", authBearerToken: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
 
     /// INT environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    static let int = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-beta")!, requestReference: "OJP_Demo_iOS", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    static let int = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-beta")!, requestReference: "OJP_Demo_iOS", authBearerToken: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
 }

--- a/Sources/OJP/APIConfiguration.swift
+++ b/Sources/OJP/APIConfiguration.swift
@@ -10,28 +10,28 @@ import Foundation
 /// Defines the access to OJP Service
 public struct APIConfiguration {
     public let apiEndPoint: URL
-    public let requestReference: String
+    public let requesterReference: String
     public let authBearerToken: String?
     public let additionalHeaders: [(key: String, value: String)]?
 
     /// Configuration for the API
     /// - Parameters:
     ///   - apiEndPoint: the URL that points to the backend API
-    ///   - requestReference: a reference that will be added to the XML repreresenting your client
+    ///   - requesterReference: a reference that will be added to the XML repreresenting your client
     ///   - authBearerToken: a Bearer token, it's send in this manner: Authorization: Bearer <your token>
     ///   - additionalHeaders: some HTTP custom headers
-    public init(apiEndPoint: URL, requestReference: String, authBearerToken: String? = nil, additionalHeaders: [(key: String, value: String)]? = nil) {
+    public init(apiEndPoint: URL, requesterReference: String, authBearerToken: String? = nil, additionalHeaders: [(key: String, value: String)]? = nil) {
         self.apiEndPoint = apiEndPoint
-        self.requestReference = "\(requestReference)_\(OJP_SDK_Name)_\(OJP_SDK_Version)"
+        self.requesterReference = "\(requesterReference)_\(OJP_SDK_Name)_\(OJP_SDK_Version)"
         self.authBearerToken = authBearerToken
         self.additionalHeaders = additionalHeaders
     }
 
     /// TEST environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    static let test = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-test")!, requestReference: "OJP_Demo_iOS", authBearerToken: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    static let test = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-test")!, requesterReference: "OJP_Demo_iOS", authBearerToken: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
 
     /// INT environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    static let int = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-beta")!, requestReference: "OJP_Demo_iOS", authBearerToken: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    static let int = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-beta")!, requesterReference: "OJP_Demo_iOS", authBearerToken: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
 }

--- a/Sources/OJP/APIConfiguration.swift
+++ b/Sources/OJP/APIConfiguration.swift
@@ -9,12 +9,12 @@ import Foundation
 
 /// Defines the access to OJP Service
 public struct APIConfiguration {
-    public let apiEndPoint: String
+    public let apiEndPoint: URL
     public let requestReference: String
     public let accessToken: String?
     public let additionalHeaders: [(key: String, value: String)]?
 
-    public init(apiEndPoint: String, requestReference: String, authBearerKey: String? = nil, additionalHeaders: [(key: String, value: String)]? = nil) {
+    public init(apiEndPoint: URL, requestReference: String, authBearerKey: String? = nil, additionalHeaders: [(key: String, value: String)]? = nil) {
         self.apiEndPoint = apiEndPoint
         self.requestReference = "\(requestReference)_\(OJP_SDK_Version)"
         accessToken = authBearerKey
@@ -23,9 +23,9 @@ public struct APIConfiguration {
 
     /// TEST environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    static let test = Self(apiEndPoint: "https://odpch-api.clients.liip.ch/ojp20-test", requestReference: "OJP_Demo_iOS", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    static let test = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-test")!, requestReference: "OJP_Demo_iOS", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
 
     /// INT environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    static let int = Self(apiEndPoint: "https://odpch-api.clients.liip.ch/ojp20-beta", requestReference: "OJP_Demo_iOS", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    static let int = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-beta")!, requestReference: "OJP_Demo_iOS", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
 }

--- a/Sources/OJP/APIConfiguration.swift
+++ b/Sources/OJP/APIConfiguration.swift
@@ -14,18 +14,18 @@ public struct APIConfiguration {
     public let accessToken: String?
     public let additionalHeaders: [(key: String, value: String)]?
 
-    public init(apiEndPoint: String, requestorRef: String, authBearerKey: String? = nil, additionalHeaders: [(key: String, value: String)]? = nil) {
+    public init(apiEndPoint: String, requestReference: String, authBearerKey: String? = nil, additionalHeaders: [(key: String, value: String)]? = nil) {
         self.apiEndPoint = apiEndPoint
-        self.requestReference = "\(requestorRef)_\(OJP_SDK_Version)"
-        self.accessToken = authBearerKey
+        self.requestReference = "\(requestReference)_\(OJP_SDK_Version)"
+        accessToken = authBearerKey
         self.additionalHeaders = additionalHeaders
     }
 
     /// TEST environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    internal static let test = Self(apiEndPoint: "https://odpch-api.clients.liip.ch/ojp20-test", requestorRef: "OJP_Demo_iOS_\(OJP_SDK_Version)", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    static let test = Self(apiEndPoint: "https://odpch-api.clients.liip.ch/ojp20-test", requestReference: "OJP_Demo_iOS", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
 
     /// INT environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    internal static let int = Self(apiEndPoint: "https://odpch-api.clients.liip.ch/ojp20-beta", requestorRef: "OJP_Demo_iOS_\(OJP_SDK_Version)", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    static let int = Self(apiEndPoint: "https://odpch-api.clients.liip.ch/ojp20-beta", requestReference: "OJP_Demo_iOS", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
 }

--- a/Sources/OJP/APIConfiguration.swift
+++ b/Sources/OJP/APIConfiguration.swift
@@ -10,20 +10,22 @@ import Foundation
 /// Defines the access to OJP Service
 public struct APIConfiguration {
     public let apiEndPoint: String
-    public let authBearerKey: String
+    public let requestorRef: String
+    public let authBearerKey: String?
     public let additionalHeaders: [(key: String, value: String)]?
 
-    public init(apiEndPoint: String, authBearerKey: String, additionalHeaders: [(key: String, value: String)]? = nil) {
+    public init(apiEndPoint: String, requestorRef: String, authBearerKey: String? = nil, additionalHeaders: [(key: String, value: String)]? = nil) {
         self.apiEndPoint = apiEndPoint
+        self.requestorRef = "\(requestorRef)_\(OJP_SDK_Version)"
         self.authBearerKey = authBearerKey
         self.additionalHeaders = additionalHeaders
     }
 
     /// TEST environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    public static let test = Self(apiEndPoint: "https://odpch-api.clients.liip.ch/ojp20-test", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    internal static let test = Self(apiEndPoint: "https://odpch-api.clients.liip.ch/ojp20-test", requestorRef: "OJP_Demo_iOS_\(OJP_SDK_Version)", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
 
     /// INT environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    public static let int = Self(apiEndPoint: "https://odpch-api.clients.liip.ch/ojp20-beta", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    internal static let int = Self(apiEndPoint: "https://odpch-api.clients.liip.ch/ojp20-beta", requestorRef: "OJP_Demo_iOS_\(OJP_SDK_Version)", authBearerKey: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
 }

--- a/Sources/OJP/APIConfiguration.swift
+++ b/Sources/OJP/APIConfiguration.swift
@@ -10,14 +10,14 @@ import Foundation
 /// Defines the access to OJP Service
 public struct APIConfiguration {
     public let apiEndPoint: String
-    public let requestorRef: String
-    public let authBearerKey: String?
+    public let requestReference: String
+    public let accessToken: String?
     public let additionalHeaders: [(key: String, value: String)]?
 
     public init(apiEndPoint: String, requestorRef: String, authBearerKey: String? = nil, additionalHeaders: [(key: String, value: String)]? = nil) {
         self.apiEndPoint = apiEndPoint
-        self.requestorRef = "\(requestorRef)_\(OJP_SDK_Version)"
-        self.authBearerKey = authBearerKey
+        self.requestReference = "\(requestorRef)_\(OJP_SDK_Version)"
+        self.accessToken = authBearerKey
         self.additionalHeaders = additionalHeaders
     }
 

--- a/Sources/OJP/HTTPLoader.swift
+++ b/Sources/OJP/HTTPLoader.swift
@@ -25,7 +25,9 @@ public class HTTPLoader {
         let url = URL(string: configuration.apiEndPoint)!
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
-        urlRequest.addValue("Bearer \(configuration.authBearerKey)", forHTTPHeaderField: "Authorization")
+        if let authBearerKey = configuration.authBearerKey {
+            urlRequest.addValue("Bearer \(authBearerKey)", forHTTPHeaderField: "Authorization")
+        }
         urlRequest.addValue("application/xml", forHTTPHeaderField: "Content-Type")
 
         if let headers = configuration.additionalHeaders {

--- a/Sources/OJP/HTTPLoader.swift
+++ b/Sources/OJP/HTTPLoader.swift
@@ -25,7 +25,7 @@ public class HTTPLoader {
         let url = URL(string: configuration.apiEndPoint)!
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
-        if let authBearerKey = configuration.authBearerKey {
+        if let authBearerKey = configuration.accessToken {
             urlRequest.addValue("Bearer \(authBearerKey)", forHTTPHeaderField: "Authorization")
         }
         urlRequest.addValue("application/xml", forHTTPHeaderField: "Content-Type")

--- a/Sources/OJP/HTTPLoader.swift
+++ b/Sources/OJP/HTTPLoader.swift
@@ -24,7 +24,7 @@ public class HTTPLoader {
     private var baseRequest: URLRequest {
         var urlRequest = URLRequest(url: configuration.apiEndPoint)
         urlRequest.httpMethod = "POST"
-        if let authBearerKey = configuration.accessToken {
+        if let authBearerKey = configuration.authBearerToken {
             urlRequest.addValue("Bearer \(authBearerKey)", forHTTPHeaderField: "Authorization")
         }
         urlRequest.addValue("application/xml", forHTTPHeaderField: "Content-Type")

--- a/Sources/OJP/HTTPLoader.swift
+++ b/Sources/OJP/HTTPLoader.swift
@@ -22,8 +22,7 @@ public class HTTPLoader {
     }
 
     private var baseRequest: URLRequest {
-        let url = URL(string: configuration.apiEndPoint)!
-        var urlRequest = URLRequest(url: url)
+        var urlRequest = URLRequest(url: configuration.apiEndPoint)
         urlRequest.httpMethod = "POST"
         if let authBearerKey = configuration.accessToken {
             urlRequest.addValue("Bearer \(authBearerKey)", forHTTPHeaderField: "Authorization")

--- a/Sources/OJP/Models/OJPv2.swift
+++ b/Sources/OJP/Models/OJPv2.swift
@@ -35,7 +35,7 @@ public struct OJPv2: Codable {
     let request: Request?
     let response: Response?
 
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case request = "OJPRequest"
         case response = "OJPResponse"
     }

--- a/Sources/OJP/Models/OJPv2.swift
+++ b/Sources/OJP/Models/OJPv2.swift
@@ -31,15 +31,15 @@ struct StrippedPrefixCodingKey: CodingKey {
 }
 
 public struct OJPv2: Codable {
-    internal let request: Request?
-    internal let response: Response?
+    let request: Request?
+    let response: Response?
 
     public enum CodingKeys: String, CodingKey {
         case request = "OJPRequest"
         case response = "OJPResponse"
     }
 
-    internal struct Response: Codable {
+    struct Response: Codable {
         public let serviceDelivery: ServiceDelivery
 
         public enum CodingKeys: String, CodingKey {
@@ -52,7 +52,7 @@ public struct OJPv2: Codable {
         }
     }
 
-    internal struct ServiceDelivery: Codable {
+    struct ServiceDelivery: Codable {
         public let responseTimestamp: String
         public let producerRef: String
         public let delivery: ServiceDeliveryType
@@ -71,7 +71,7 @@ public struct OJPv2: Codable {
         }
     }
 
-    internal enum ServiceDeliveryType: Codable {
+    enum ServiceDeliveryType: Codable {
         case stopEvent(OJPv2.StopEventServiceDelivery)
         case locationInformation(OJPv2.LocationInformationDelivery)
 
@@ -95,10 +95,10 @@ public struct OJPv2: Codable {
         }
     }
 
-    internal struct StopEventServiceDelivery: Codable {
-        internal let responseTimestamp: String
-        internal let producerRef: String
-        internal let stopEventDelivery: StopEventDelivery
+    struct StopEventServiceDelivery: Codable {
+        let responseTimestamp: String
+        let producerRef: String
+        let stopEventDelivery: StopEventDelivery
 
         public enum CodingKeys: String, CodingKey {
             case responseTimestamp = "siri:ResponseTimestamp"
@@ -107,11 +107,11 @@ public struct OJPv2: Codable {
         }
     }
 
-    internal struct StopEventDelivery: Codable {
+    struct StopEventDelivery: Codable {
         let places: [Place]
     }
 
-    internal struct LocationInformationServiceDelivery: Codable {
+    struct LocationInformationServiceDelivery: Codable {
         public let responseTimestamp: String
         public let producerRef: String
         public let locationInformationDelivery: LocationInformationDelivery
@@ -131,7 +131,7 @@ public struct OJPv2: Codable {
         }
     }
 
-    internal struct LocationInformationDelivery: Codable {
+    struct LocationInformationDelivery: Codable {
         public let responseTimestamp: String
         public let requestMessageRef: String
         public let defaultLanguage: String
@@ -181,10 +181,10 @@ public struct OJPv2: Codable {
             case mode = "Mode"
         }
     }
-    
+
     public struct Mode: Codable {
         public let ptMode: String
-        
+
         public enum CodingKeys: String, CodingKey {
             case ptMode = "PtMode"
         }
@@ -244,7 +244,7 @@ public struct OJPv2: Codable {
         }
     }
 
-    internal struct Request: Codable {
+    struct Request: Codable {
         public let serviceRequest: ServiceRequest
 
         public enum CodingKeys: String, CodingKey {
@@ -252,7 +252,7 @@ public struct OJPv2: Codable {
         }
     }
 
-    internal struct ServiceRequest: Codable {
+    struct ServiceRequest: Codable {
         public let requestTimestamp: String
         public let requestorRef: String
         public let locationInformationRequest: LocationInformationRequest
@@ -264,7 +264,7 @@ public struct OJPv2: Codable {
         }
     }
 
-    internal struct LocationInformationRequest: Codable {
+    struct LocationInformationRequest: Codable {
         public let requestTimestamp: String
         public let initialInput: InitialInput
         public let restrictions: Restrictions
@@ -276,7 +276,7 @@ public struct OJPv2: Codable {
         }
     }
 
-    internal struct InitialInput: Codable {
+    struct InitialInput: Codable {
         public let geoRestriction: GeoRestriction?
         public let name: String?
 
@@ -286,7 +286,7 @@ public struct OJPv2: Codable {
         }
     }
 
-    internal struct GeoRestriction: Codable {
+    struct GeoRestriction: Codable {
         public let rectangle: Rectangle?
 
         public enum CodingKeys: String, CodingKey {

--- a/Sources/OJP/Models/OJPv2.swift
+++ b/Sources/OJP/Models/OJPv2.swift
@@ -8,8 +8,8 @@
 import Foundation
 import XMLCoder
 
-internal let OJP_SDK_Name = "IOS_SDK"
-internal let OJP_SDK_Version = "0.0.1"
+let OJP_SDK_Name = "IOS_SDK"
+let OJP_SDK_Version = "0.0.1"
 
 struct StrippedPrefixCodingKey: CodingKey {
     var stringValue: String

--- a/Sources/OJP/Models/OJPv2.swift
+++ b/Sources/OJP/Models/OJPv2.swift
@@ -8,7 +8,8 @@
 import Foundation
 import XMLCoder
 
-let OJP_SDK_Version = "0.9.1"
+internal let OJP_SDK_Name = "IOS_SDK"
+internal let OJP_SDK_Version = "0.0.1"
 
 struct StrippedPrefixCodingKey: CodingKey {
     var stringValue: String

--- a/Sources/OJP/OJP.swift
+++ b/Sources/OJP/OJP.swift
@@ -16,14 +16,17 @@ public enum LoadingStrategy {
 /// Entry point to OJP
 public class OJP {
     let loader: Loader
-
+    let locationInformationRequest: OJPHelpers.LocationInformationRequest
+    
     public init(loadingStrategy: LoadingStrategy) {
         switch loadingStrategy {
         case let .http(apiConfiguration):
             let httpLoader = HTTPLoader(configuration: apiConfiguration)
             loader = httpLoader.load(request:)
+            locationInformationRequest = OJPHelpers.LocationInformationRequest(requestorRef: apiConfiguration.requestorRef)
         case let .mock(loader):
             self.loader = loader
+            locationInformationRequest = OJPHelpers.LocationInformationRequest(requestorRef: "Mock_Requestor_Ref")
         }
     }
 
@@ -50,7 +53,7 @@ public class OJP {
     }
 
     public func nearbyStations(from point: Point) async throws -> [NearbyObject<OJPv2.PlaceResult>] {
-        let ojp = OJPHelpers.LocationInformationRequest.requestWithBox(centerLongitude: point.long, centerLatitude: point.lat, boxWidth: 500.0)
+        let ojp = locationInformationRequest.requestWithBox(centerLongitude: point.long, centerLatitude: point.lat, boxWidth: 500.0)
 
         let serviceDelivery = try await request(with: ojp).serviceDelivery
 
@@ -64,7 +67,7 @@ public class OJP {
     }
 
     public func stations(by stopName: String, limit: Int = 10) async throws -> [OJPv2.PlaceResult] {
-        let ojp = OJPHelpers.LocationInformationRequest.requestWithStopName(stopName);
+        let ojp = locationInformationRequest.requestWithStopName(stopName);
         
         let serviceDelivery = try await request(with: ojp).serviceDelivery
 

--- a/Sources/OJP/OJP.swift
+++ b/Sources/OJP/OJP.swift
@@ -23,7 +23,7 @@ public class OJP {
         case let .http(apiConfiguration):
             let httpLoader = HTTPLoader(configuration: apiConfiguration)
             loader = httpLoader.load(request:)
-            locationInformationRequest = OJPHelpers.LocationInformationRequest(requestorRef: apiConfiguration.requestorRef)
+            locationInformationRequest = OJPHelpers.LocationInformationRequest(requestorRef: apiConfiguration.requestReference)
         case let .mock(loader):
             self.loader = loader
             locationInformationRequest = OJPHelpers.LocationInformationRequest(requestorRef: "Mock_Requestor_Ref")
@@ -51,9 +51,9 @@ public class OJP {
         decoder.keyDecodingStrategy = .useDefaultKeys
         return decoder
     }
-
-    public func nearbyStations(from point: Point) async throws -> [NearbyObject<OJPv2.PlaceResult>] {
-        let ojp = locationInformationRequest.requestWithBox(centerLongitude: point.long, centerLatitude: point.lat, boxWidth: 500.0)
+    
+    public func requestPlaceResults(from coordinates: Point) async throws -> [NearbyObject<OJPv2.PlaceResult>] {
+        let ojp = locationInformationRequest.requestWithBox(centerLongitude: coordinates.long, centerLatitude: coordinates.lat, boxWidth: 1000.0)
 
         let serviceDelivery = try await request(with: ojp).serviceDelivery
 
@@ -61,13 +61,13 @@ public class OJP {
             throw OJPError.unexpectedEmpty
         }
 
-        let nearbyObjects = GeoHelpers.sort(geoAwareObjects: locationInformationDelivery.placeResults, from: point)
+        let nearbyObjects = GeoHelpers.sort(geoAwareObjects: locationInformationDelivery.placeResults, from: coordinates)
 
         return nearbyObjects
     }
 
-    public func stations(by stopName: String, limit: Int = 10) async throws -> [OJPv2.PlaceResult] {
-        let ojp = locationInformationRequest.requestWithStopName(stopName);
+    public func requestPlaceResults(from searchTerm: String) async throws -> [OJPv2.PlaceResult] {
+        let ojp = locationInformationRequest.requestWithSearchTerm(searchTerm);
         
         let serviceDelivery = try await request(with: ojp).serviceDelivery
 

--- a/Sources/OJP/OJP.swift
+++ b/Sources/OJP/OJP.swift
@@ -24,10 +24,10 @@ public class OJP {
         case let .http(apiConfiguration):
             let httpLoader = HTTPLoader(configuration: apiConfiguration)
             loader = httpLoader.load(request:)
-            locationInformationRequest = OJPHelpers.LocationInformationRequest(requestorRef: apiConfiguration.requestReference)
+            locationInformationRequest = OJPHelpers.LocationInformationRequest(requesterReference: apiConfiguration.requesterReference)
         case let .mock(loader):
             self.loader = loader
-            locationInformationRequest = OJPHelpers.LocationInformationRequest(requestorRef: "Mock_Requestor_Ref")
+            locationInformationRequest = OJPHelpers.LocationInformationRequest(requesterReference: "Mock_Requestor_Ref")
         }
     }
 

--- a/Sources/OJP/OJPHelpers.swift
+++ b/Sources/OJP/OJPHelpers.swift
@@ -91,12 +91,12 @@ enum OJPHelpers {
             return ojp
         }
         
-        /// Creates a new OJP LocationInformationRequest with stop name
+        /// Creates a new OJP LocationInformationRequest with a search term
         /// - Parameters:
-        ///   - name: stop name
+        ///   - name: search term (the name of a stop)
         ///   - limit: results limit
         /// - Returns: OJPv2 containing a request
-        public func requestWithStopName(_ name: String, numberOfResults: Int = 10) -> OJPv2 {
+        public func requestWithSearchTerm(_ name: String, numberOfResults: Int = 10) -> OJPv2 {
             let requestTimestamp = OJPHelpers.formattedDate()
             let restrictions = OJPv2.Restrictions(type: "stop", numberOfResults: numberOfResults, includePtModes: true)
             

--- a/Sources/OJP/OJPHelpers.swift
+++ b/Sources/OJP/OJPHelpers.swift
@@ -29,12 +29,19 @@ enum OJPHelpers {
     }
 
     class LocationInformationRequest {
+        
+        init(requestorRef: String) {
+            self.requestorRef = requestorRef
+        }
+        
+        let requestorRef: String
+        
         /// Creates a new OJP LocationInformationRequest with bounding box
         /// - Parameters
         ///   - bbox: Bounding box used as ``OJPv2/GeoRestriction``
         ///   - limit: results limit
         /// - Returns: OJPv2 containing a request
-        public static func requestWith(bbox: Geo.Bbox, numberOfResults: Int = 10) -> OJPv2 {
+        public func requestWith(bbox: Geo.Bbox, numberOfResults: Int = 10) -> OJPv2 {
             let requestTimestamp = OJPHelpers.formattedDate()
 
             let upperLeft = OJPv2.GeoPosition(longitude: bbox.minX, latitude: bbox.maxY)
@@ -45,7 +52,6 @@ enum OJPHelpers {
 
             let locationInformationRequest = OJPv2.LocationInformationRequest(requestTimestamp: requestTimestamp, initialInput: OJPv2.InitialInput(geoRestriction: geoRestriction, name: nil), restrictions: restrictions)
 
-            let requestorRef = "OJP_Demo_iOS_\(OJP_SDK_Version)"
             let ojp = OJPv2(request: OJPv2.Request(serviceRequest: OJPv2.ServiceRequest(requestTimestamp: requestTimestamp, requestorRef: requestorRef, locationInformationRequest: locationInformationRequest)), response: nil)
 
             return ojp
@@ -59,7 +65,7 @@ enum OJPHelpers {
         ///   - boxHeight: bounding box  height in meters
         ///   - limit: results limit
         /// - Returns: OJPv2 containing a request
-        public static func requestWithBox(centerLongitude: Double, centerLatitude: Double, boxWidth: Double, boxHeight: Double? = nil, numberOfResults: Int = 10) -> OJPv2 {
+        public func requestWithBox(centerLongitude: Double, centerLatitude: Double, boxWidth: Double, boxHeight: Double? = nil, numberOfResults: Int = 10) -> OJPv2 {
             let boxHeight = boxHeight ?? boxWidth
 
             let point2Longitude = centerLongitude + 1
@@ -80,7 +86,7 @@ enum OJPHelpers {
 
             let bbox = Geo.Bbox(minLongitude: minLongitude, minLatitude: minLatitude, maxLongitude: maxLongitude, maxLatitude: maxLatitude)
 
-            let ojp = LocationInformationRequest.requestWith(bbox: bbox, numberOfResults: numberOfResults)
+            let ojp = requestWith(bbox: bbox, numberOfResults: numberOfResults)
 
             return ojp
         }
@@ -90,14 +96,13 @@ enum OJPHelpers {
         ///   - name: stop name
         ///   - limit: results limit
         /// - Returns: OJPv2 containing a request
-        public static func requestWithStopName(_ name: String, numberOfResults: Int = 10) -> OJPv2 {
+        public func requestWithStopName(_ name: String, numberOfResults: Int = 10) -> OJPv2 {
             let requestTimestamp = OJPHelpers.formattedDate()
             let restrictions = OJPv2.Restrictions(type: "stop", numberOfResults: numberOfResults, includePtModes: true)
             
             let locationInformationRequest = OJPv2.LocationInformationRequest(requestTimestamp: requestTimestamp, initialInput: OJPv2.InitialInput(geoRestriction: nil, name: name), restrictions: restrictions)
             
             // TODO - avoid duplication (share this block with "requestWith(bbox: Geo.Bbox")
-            let requestorRef = "OJP_Demo_iOS_\(OJP_SDK_Version)"
             let ojp = OJPv2(request: OJPv2.Request(serviceRequest: OJPv2.ServiceRequest(requestTimestamp: requestTimestamp, requestorRef: requestorRef, locationInformationRequest: locationInformationRequest)), response: nil)
 
             return ojp

--- a/Sources/OJP/OJPHelpers.swift
+++ b/Sources/OJP/OJPHelpers.swift
@@ -29,11 +29,11 @@ enum OJPHelpers {
     }
 
     class LocationInformationRequest {
-        init(requestorRef: String) {
-            self.requestorRef = requestorRef
+        init(requesterReference: String) {
+            self.requesterReference = requesterReference
         }
 
-        let requestorRef: String
+        let requesterReference: String
 
         /// Creates a new OJP LocationInformationRequest with bounding box
         /// - Parameters
@@ -51,7 +51,7 @@ enum OJPHelpers {
 
             let locationInformationRequest = OJPv2.LocationInformationRequest(requestTimestamp: requestTimestamp, initialInput: OJPv2.InitialInput(geoRestriction: geoRestriction, name: nil), restrictions: restrictions)
 
-            let ojp = OJPv2(request: OJPv2.Request(serviceRequest: OJPv2.ServiceRequest(requestTimestamp: requestTimestamp, requestorRef: requestorRef, locationInformationRequest: locationInformationRequest)), response: nil)
+            let ojp = OJPv2(request: OJPv2.Request(serviceRequest: OJPv2.ServiceRequest(requestTimestamp: requestTimestamp, requestorRef: requesterReference, locationInformationRequest: locationInformationRequest)), response: nil)
 
             return ojp
         }
@@ -102,7 +102,7 @@ enum OJPHelpers {
             let locationInformationRequest = OJPv2.LocationInformationRequest(requestTimestamp: requestTimestamp, initialInput: OJPv2.InitialInput(geoRestriction: nil, name: name), restrictions: restrictions)
 
             // TODO: - avoid duplication (share this block with "requestWith(bbox: Geo.Bbox")
-            let ojp = OJPv2(request: OJPv2.Request(serviceRequest: OJPv2.ServiceRequest(requestTimestamp: requestTimestamp, requestorRef: requestorRef, locationInformationRequest: locationInformationRequest)), response: nil)
+            let ojp = OJPv2(request: OJPv2.Request(serviceRequest: OJPv2.ServiceRequest(requestTimestamp: requestTimestamp, requestorRef: requesterReference, locationInformationRequest: locationInformationRequest)), response: nil)
 
             return ojp
         }

--- a/Sources/OJP/OJPHelpers.swift
+++ b/Sources/OJP/OJPHelpers.swift
@@ -29,13 +29,12 @@ enum OJPHelpers {
     }
 
     class LocationInformationRequest {
-        
         init(requestorRef: String) {
             self.requestorRef = requestorRef
         }
-        
+
         let requestorRef: String
-        
+
         /// Creates a new OJP LocationInformationRequest with bounding box
         /// - Parameters
         ///   - bbox: Bounding box used as ``OJPv2/GeoRestriction``
@@ -90,7 +89,7 @@ enum OJPHelpers {
 
             return ojp
         }
-        
+
         /// Creates a new OJP LocationInformationRequest with a search term
         /// - Parameters:
         ///   - name: search term (the name of a stop)
@@ -99,10 +98,10 @@ enum OJPHelpers {
         public func requestWithSearchTerm(_ name: String, numberOfResults: Int = 10) -> OJPv2 {
             let requestTimestamp = OJPHelpers.formattedDate()
             let restrictions = OJPv2.Restrictions(type: "stop", numberOfResults: numberOfResults, includePtModes: true)
-            
+
             let locationInformationRequest = OJPv2.LocationInformationRequest(requestTimestamp: requestTimestamp, initialInput: OJPv2.InitialInput(geoRestriction: nil, name: name), restrictions: restrictions)
-            
-            // TODO - avoid duplication (share this block with "requestWith(bbox: Geo.Bbox")
+
+            // TODO: - avoid duplication (share this block with "requestWith(bbox: Geo.Bbox")
             let ojp = OJPv2(request: OJPv2.Request(serviceRequest: OJPv2.ServiceRequest(requestTimestamp: requestTimestamp, requestorRef: requestorRef, locationInformationRequest: locationInformationRequest)), response: nil)
 
             return ojp

--- a/Tests/OJPTests/OjpSDKTests.swift
+++ b/Tests/OJPTests/OjpSDKTests.swift
@@ -2,6 +2,9 @@
 import XCTest
 
 final class OjpSDKTests: XCTestCase {
+    
+    let locationInformationRequest = OJPHelpers.LocationInformationRequest(requestorRef: "")
+    
     func testLoadFromBundle() throws {
         do {
             let data = try TestHelpers.loadXML()
@@ -13,7 +16,7 @@ final class OjpSDKTests: XCTestCase {
 
     func testGeoRestrictionHelpers() throws {
         // BBOX with Kleine Schanze as center + width / height of 1km
-        let ojp = OJPHelpers.LocationInformationRequest.requestWithBox(centerLongitude: 7.44029, centerLatitude: 46.94578, boxWidth: 1000.0)
+        let ojp = locationInformationRequest.requestWithBox(centerLongitude: 7.44029, centerLatitude: 46.94578, boxWidth: 1000.0)
 
         if let rectangle = ojp.request?.serviceRequest.locationInformationRequest.initialInput.geoRestriction?.rectangle {
             XCTAssertTrue(rectangle.lowerRight.longitude > rectangle.upperLeft.longitude)
@@ -35,7 +38,7 @@ final class OjpSDKTests: XCTestCase {
             let response = HTTPURLResponse(url: URL(string: "https://localhost")!, statusCode: 200, httpVersion: "1.0", headerFields: [:])
             return (data, response!)
         }
-
+        
         let ojpSdk = OJP(loadingStrategy: .mock(mockLoader))
         let nearbyStations = try await ojpSdk.nearbyStations(from: (long: 7.452178, lat: 46.948474))
 
@@ -53,14 +56,14 @@ final class OjpSDKTests: XCTestCase {
     func testBuildRequestBBOX() throws {
         // BE/Köniz area
         let bbox = Geo.Bbox(minLongitude: 7.372097, minLatitude: 46.904860, maxLongitude: 7.479042, maxLatitude: 46.942787)
-        let ojpRequest = OJPHelpers.LocationInformationRequest.requestWith(bbox: bbox)
+        let ojpRequest = locationInformationRequest.requestWith(bbox: bbox)
         
         let xmlString = try OJPHelpers.buildXMLRequest(ojpRequest: ojpRequest)
         XCTAssert(!xmlString.isEmpty)
     }
     
     func testBuildRequestName() throws {
-        let ojpRequest = OJPHelpers.LocationInformationRequest.requestWithStopName("Be")
+        let ojpRequest = locationInformationRequest.requestWithStopName("Be")
         let xmlString = try OJPHelpers.buildXMLRequest(ojpRequest: ojpRequest)
         XCTAssert(!xmlString.isEmpty)
     }
@@ -89,7 +92,7 @@ final class OjpSDKTests: XCTestCase {
     func testLoader() async throws {
         // BE/Köniz area
         let bbox = Geo.Bbox(minLongitude: 7.372097, minLatitude: 46.904860, maxLongitude: 7.479042, maxLatitude: 46.942787)
-        let ojpRequest = OJPHelpers.LocationInformationRequest.requestWith(bbox: bbox)
+        let ojpRequest = locationInformationRequest.requestWith(bbox: bbox)
 
         let body = try OJPHelpers.buildXMLRequest(ojpRequest: ojpRequest).data(using: .utf8)!
 
@@ -118,7 +121,7 @@ final class OjpSDKTests: XCTestCase {
     func testMockLoader() async throws {
         // BE/Köniz area
         let bbox = Geo.Bbox(minLongitude: 7.372097, minLatitude: 46.904860, maxLongitude: 7.479042, maxLatitude: 46.942787)
-        let ojpRequest = OJPHelpers.LocationInformationRequest.requestWith(bbox: bbox)
+        let ojpRequest = locationInformationRequest.requestWith(bbox: bbox)
 
         let body = try OJPHelpers.buildXMLRequest(ojpRequest: ojpRequest).data(using: .utf8)!
 

--- a/Tests/OJPTests/OjpSDKTests.swift
+++ b/Tests/OJPTests/OjpSDKTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 final class OjpSDKTests: XCTestCase {
-    let locationInformationRequest = OJPHelpers.LocationInformationRequest(requestorRef: "")
+    let locationInformationRequest = OJPHelpers.LocationInformationRequest(requesterReference: "")
 
     func testLoadFromBundle() throws {
         do {

--- a/Tests/OJPTests/OjpSDKTests.swift
+++ b/Tests/OJPTests/OjpSDKTests.swift
@@ -40,7 +40,7 @@ final class OjpSDKTests: XCTestCase {
         }
         
         let ojpSdk = OJP(loadingStrategy: .mock(mockLoader))
-        let nearbyStations = try await ojpSdk.nearbyStations(from: (long: 7.452178, lat: 46.948474))
+        let nearbyStations = try await ojpSdk.requestPlaceResults(from: (long: 7.452178, lat: 46.948474))
 
         let nearbyPlaceResult = nearbyStations.first!.object
 
@@ -63,7 +63,7 @@ final class OjpSDKTests: XCTestCase {
     }
     
     func testBuildRequestName() throws {
-        let ojpRequest = locationInformationRequest.requestWithStopName("Be")
+        let ojpRequest = locationInformationRequest.requestWithSearchTerm("Be")
         let xmlString = try OJPHelpers.buildXMLRequest(ojpRequest: ojpRequest)
         XCTAssert(!xmlString.isEmpty)
     }
@@ -152,7 +152,7 @@ final class OjpSDKTests: XCTestCase {
     func testFetchNearbyStations() async throws {
         let ojpSdk = OJP(loadingStrategy: .http(.int))
 
-        let nearbyStations = try await ojpSdk.nearbyStations(from: (long: 7.452178, lat: 46.948474))
+        let nearbyStations = try await ojpSdk.requestPlaceResults(from: (long: 7.452178, lat: 46.948474))
 
         XCTAssert(nearbyStations.first!.object.place.name.text == "Rathaus")
     }

--- a/Tests/OJPTests/OjpSDKTests.swift
+++ b/Tests/OJPTests/OjpSDKTests.swift
@@ -2,9 +2,8 @@
 import XCTest
 
 final class OjpSDKTests: XCTestCase {
-    
     let locationInformationRequest = OJPHelpers.LocationInformationRequest(requestorRef: "")
-    
+
     func testLoadFromBundle() throws {
         do {
             let data = try TestHelpers.loadXML()
@@ -38,9 +37,9 @@ final class OjpSDKTests: XCTestCase {
             let response = HTTPURLResponse(url: URL(string: "https://localhost")!, statusCode: 200, httpVersion: "1.0", headerFields: [:])
             return (data, response!)
         }
-        
+
         let ojpSdk = OJP(loadingStrategy: .mock(mockLoader))
-        let nearbyStations = try await ojpSdk.requestPlaceResults(from: (long: 7.452178, lat: 46.948474))
+        let nearbyStations = try await ojpSdk.requestLocations(from: (long: 7.452178, lat: 46.948474))
 
         let nearbyPlaceResult = nearbyStations.first!.object
 
@@ -57,11 +56,11 @@ final class OjpSDKTests: XCTestCase {
         // BE/Köniz area
         let bbox = Geo.Bbox(minLongitude: 7.372097, minLatitude: 46.904860, maxLongitude: 7.479042, maxLatitude: 46.942787)
         let ojpRequest = locationInformationRequest.requestWith(bbox: bbox)
-        
+
         let xmlString = try OJPHelpers.buildXMLRequest(ojpRequest: ojpRequest)
         XCTAssert(!xmlString.isEmpty)
     }
-    
+
     func testBuildRequestName() throws {
         let ojpRequest = locationInformationRequest.requestWithSearchTerm("Be")
         let xmlString = try OJPHelpers.buildXMLRequest(ojpRequest: ojpRequest)
@@ -152,7 +151,7 @@ final class OjpSDKTests: XCTestCase {
     func testFetchNearbyStations() async throws {
         let ojpSdk = OJP(loadingStrategy: .http(.int))
 
-        let nearbyStations = try await ojpSdk.requestPlaceResults(from: (long: 7.452178, lat: 46.948474))
+        let nearbyStations = try await ojpSdk.requestLocations(from: (long: 7.452178, lat: 46.948474))
 
         XCTAssert(nearbyStations.first!.object.place.name.text == "Rathaus")
     }


### PR DESCRIPTION
-Add RequestorRef as parameter for the SDK Initialization
-AuthBearerKey is now not mandatory anymore (if someone wants to use the additionalHeaders)
-Added some stuff to Readme
-Rename some public methods / params, in order to have the same API as the Android SDK