### PR TITLE
Proposal for handling optional `geoPosition` and GeoAware

### DIFF
--- a/Sources/OJP/GeoHelpers.swift
+++ b/Sources/OJP/GeoHelpers.swift
@@ -28,14 +28,14 @@ enum GeoHelpers {
         return distanceMeters.rounded(to: 1)
     }
 
-    public static func sort<T: GeoAware>(geoAwareObjects: [T], from point: Point) -> [NearbyObject<T>] {
-        var nearbyObjects = geoAwareObjects.map { geoAwareObject in
-            let distance = GeoHelpers.calculateDistance(lon1: point.long, lat1: point.lat, lon2: geoAwareObject.coords.long, lat2: geoAwareObject.coords.lat)
-            return NearbyObject(object: geoAwareObject, distance: distance)
+    static func sort<T>(geoAwareObjects: [GeoAware<T>], from point: Point) -> [NearbyObject<T>] {
+        var nearbyObjects = geoAwareObjects.map {
+            return NearbyObject(
+                geoAware: $0,
+                point: point
+            )
         }
-
         nearbyObjects.sort { $0.distance < $1.distance }
-
         return nearbyObjects
     }
 }

--- a/Sources/OJP/Models/Geo.swift
+++ b/Sources/OJP/Models/Geo.swift
@@ -31,9 +31,17 @@ public struct Geo {
 
 public struct NearbyObject<T> {
     public var object: T
+    public internal(set) var coords: Point
     public var distance: Double
+
+    init(geoAware: GeoAware<T>, point: Point) {
+        object = geoAware.object
+        coords = geoAware.coords
+        distance = GeoHelpers.calculateDistance(lon1: point.long, lat1: point.lat, lon2: coords.long, lat2: coords.lat)
+    }
 }
 
-public protocol GeoAware {
-    var coords: Point { get }
+public struct GeoAware<T> {
+    var object: T
+    var coords: Point
 }

--- a/Sources/OJP/Models/OJPv2+Extensions.swift
+++ b/Sources/OJP/Models/OJPv2+Extensions.swift
@@ -27,10 +27,9 @@ public extension OJPv2.Mode {
     }
 }
 
-extension OJPv2.PlaceResult: GeoAware {
-    
-    public var coords: Point {
-        guard let geoPosition = place.geoPosition else { return (long: COORDINATE_FALLBACK, lat: COORDINATE_FALLBACK) }
-        return (long: geoPosition.longitude, lat: geoPosition.latitude)
+extension OJPv2.PlaceResult {
+    public var geoAware: GeoAware<Self>? {
+        guard let geoPosition = place.geoPosition else { return nil }
+        return GeoAware(object: self, coords: (long: geoPosition.longitude, lat: geoPosition.latitude))
     }
 }

--- a/Sources/OJP/OJP.swift
+++ b/Sources/OJP/OJP.swift
@@ -64,10 +64,9 @@ public class OJP {
         guard case let .locationInformation(locationInformationDelivery) = serviceDelivery.delivery else {
             throw OJPError.unexpectedEmpty
         }
+        let geoAwareObjects = locationInformationDelivery.placeResults.compactMap { $0.geoAware }
 
-        let nearbyObjects = GeoHelpers.sort(geoAwareObjects: locationInformationDelivery.placeResults, from: coordinates)
-
-        return nearbyObjects
+        return GeoHelpers.sort(geoAwareObjects: geoAwareObjects, from: coordinates)
     }
 
     /// Request a list of Locations based on the given search term


### PR DESCRIPTION
See #24 for the background.

This PR would make `GeoAware` a struct instead of a protocol in order to avoid the usual issues with protocols and associated types and handle the LIR-by-coordinate Request to exclude potential results where `geoPosition` is `nil` without defining values, that are not there by OJP