### PR TITLE
Use similar API to define custom HTTP headers as the Android SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,79 +4,77 @@
 
 This SDK is targeting iOS applications seeking to integrate [Open Journey Planner(OJP) APIs](https://opentdatach.github.io/ojp-ios/documentation/ojp/) to support distributed journey planning according to the European (CEN) Technical Specification entitled “Intelligent transport systems – Public transport – Open API for distributed journey planning”.
 
-
 Currently the SDK is under construction, so there is not yet a stable version and the APIs may change.
 
 ### Features
 
-Available APIs
+#### Available APIs
+
 - [Location Information Request](https://opentransportdata.swiss/en/cookbook/location-information-service/)
 
-Soon to be available
-- [Stop 
-Event Request](https://opentransportdata.swiss/en/cookbook/ojp-stopeventservice/)
+### Soon to be available
+
+- [Stop Event Request](https://opentransportdata.swiss/en/cookbook/ojp-stopeventservice/)
 - [Trip Request](https://opentransportdata.swiss/en/cookbook/ojptriprequest/)
 - [TripInfo Request](https://opentransportdata.swiss/en/cookbook/ojptripinforequest/)
 
 ## Requirements
 
-- Compatible with: iOS 15+ or macOS 14+
+- Compatible with: iOS 15+ and macOS 14+
 
 ## Installation
 
-- The SDK can be integrated into your Xcode project using the Swift Package Manager. To do so, just add the package by using the following url
-```
-https://github.com/openTdataCH/ojp-ios.git
-```
+- The SDK can be integrated into your Xcode project using the Swift Package Manager. To do so, just add the package by using the following: `https://github.com/openTdataCH/ojp-ios.git`
 
 ## Usage
 
 ### Initializing
+
 TBA
 - endpoints configuration
 - requesterReference
 - authBearerToken - where to get it from
 
-```
+``` swift
 import OJP
 
-let ojpSdk = OJP(loadingStrategy: .http(.init(apiEndPoint: URL(string: "your api endpoint")!, requesterReference: "your request reference", authBearerToken: "your token")))
-        
+let apiConfiguration = APIConfiguration(
+    apiEndPoint: URL(string: "your api endpoint")!, 
+    requesterReference: "your request reference", 
+    additionalHeaders: [
+        "Authorization": "Bearer yourBearerToken"
+        ]
+    )
 
+let ojpSdk = OJP(loadingStrategy: .http(apiConfiguration))
 ```
 
 ### Basic Usage
 
 Get a list of Locations from a keyword.
 
-```
+``` swift
 import OJP
 
-
 let searchedLocations = try await ojpSdk.requestLocations(from: "Bern")
-                   
-
 ```
-
 
 Get a list of Locations around a place with longitude and latitude
 
-```
+``` swift
 import OJP
 
 let nearbyLocations = try await ojpSdk.requestLocations(from: Point(long: 5.6, lat: 2.3))
-                           
-
 ```
 
+## Sample App
 
-- link to a sample app repo (later)
+WIP: on branch [demo-app](https://github.com/openTdataCH/ojp-ios/tree/demo-app)
 
 ## Documentation
 
 - [Documentation of the iOS Library](https://opentdatach.github.io/ojp-ios/documentation/ojp/)
 - run `format-code.sh` to execute swiftformat on the library
-- TBA - public OJP methods doc?
 
 ## Contributing
 

--- a/Sources/OJP/APIConfiguration.swift
+++ b/Sources/OJP/APIConfiguration.swift
@@ -11,27 +11,24 @@ import Foundation
 public struct APIConfiguration {
     public let apiEndPoint: URL
     public let requesterReference: String
-    public let authBearerToken: String?
-    public let additionalHeaders: [(key: String, value: String)]?
+    public let additionalHeaders: [String: String]?
 
     /// Configuration for the API
     /// - Parameters:
     ///   - apiEndPoint: the URL that points to the backend API
     ///   - requesterReference: a reference that will be added to the XML repreresenting your client
-    ///   - authBearerToken: a Bearer token, it's send in this manner: Authorization: Bearer <your token>
-    ///   - additionalHeaders: some HTTP custom headers
-    public init(apiEndPoint: URL, requesterReference: String, authBearerToken: String? = nil, additionalHeaders: [(key: String, value: String)]? = nil) {
+    ///   - additionalHeaders: some HTTP custom headers. For example to be used for custom authentication when using an API gateway . Example: `["Authorization": "Bearer someToken"]`
+    public init(apiEndPoint: URL, requesterReference: String, additionalHeaders: [String: String]? = nil) {
         self.apiEndPoint = apiEndPoint
         self.requesterReference = "\(requesterReference)_\(OJP_SDK_Name)_\(OJP_SDK_Version)"
-        self.authBearerToken = authBearerToken
         self.additionalHeaders = additionalHeaders
     }
 
     /// TEST environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    static let test = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-test")!, requesterReference: "OJP_Demo_iOS", authBearerToken: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    static let test = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-test")!, requesterReference: "OJP_Demo_iOS", additionalHeaders: ["Authorization": "Bearer eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9"])
 
     /// INT environment.
     /// - Note: this configuration should only be used for demo / testing purposes. It can change frequently
-    static let int = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-beta")!, requesterReference: "OJP_Demo_iOS", authBearerToken: "eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9")
+    static let int = Self(apiEndPoint: URL(string: "https://odpch-api.clients.liip.ch/ojp20-beta")!, requesterReference: "OJP_Demo_iOS", additionalHeaders: ["Authorization": "Bearer eyJvcmciOiI2M2Q4ODhiMDNmZmRmODAwMDEzMDIwODkiLCJpZCI6IjUzYzAyNWI2ZTRhNjQyOTM4NzMxMDRjNTg2ODEzNTYyIiwiaCI6Im11cm11cjEyOCJ9"])
 }

--- a/Sources/OJP/HTTPLoader.swift
+++ b/Sources/OJP/HTTPLoader.swift
@@ -24,9 +24,6 @@ public class HTTPLoader {
     private var baseRequest: URLRequest {
         var urlRequest = URLRequest(url: configuration.apiEndPoint)
         urlRequest.httpMethod = "POST"
-        if let authBearerKey = configuration.authBearerToken {
-            urlRequest.addValue("Bearer \(authBearerKey)", forHTTPHeaderField: "Authorization")
-        }
         urlRequest.addValue("application/xml", forHTTPHeaderField: "Content-Type")
 
         if let headers = configuration.additionalHeaders {


### PR DESCRIPTION
Android has no explicit property for the bearer token, but uses a map to define HTTP 
header key/value pairs.

This PR algins it in order to make the API more generic and similiar to Android