### PR TITLE
Make OJPSDKError conform to LocalizedError

### DIFF
--- a/Sources/OJP/Models/OJPv2.swift
+++ b/Sources/OJP/Models/OJPv2.swift
@@ -92,7 +92,7 @@ public struct OJPv2: Codable {
                     )
                 )
             } else {
-                throw OJPSDKError.notImplemented
+                throw OJPSDKError.notImplemented()
             }
         }
     }

--- a/Sources/OJP/OJPSDKError.swift
+++ b/Sources/OJP/OJPSDKError.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 /// ``OJPError`` describes errors that can occur when using the SDK. It is not equivalent to [OJPError](https://vdvde.github.io/OJP/develop/index.html#OJPError) that defines a sequence of OJP related problems.
-enum OJPSDKError: Error {
+enum OJPSDKError: LocalizedError {
     /// Used as a placeholder for features, that are not finished implementing
-    case notImplemented
+    case notImplemented(_ file: StaticString = #file, _ line: UInt = #line)
     /// A failure occured, while trying to access the resource
     case loadingFailed(URLError)
     /// When a response status code is != `200` this error is thrown
@@ -21,4 +21,21 @@ enum OJPSDKError: Error {
     case encodingFailed
     /// Can't correctly decode a XML response
     case decodingFailed(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .notImplemented(let file, let line):
+            "Method not Implemented in File \(file):\(line)"
+        case .unexpectedHTTPStatus(let int):
+            "Unexpected HTTP status code: \(int)"
+        case .unexpectedEmpty:
+            "Unexpeced Empty"
+        case .encodingFailed:
+            "Encoding Failed"
+        case .loadingFailed(let error):
+            "Loading Failed due to URLError: \(error.localizedDescription)"
+        case .decodingFailed(let error):
+            "Decoding Failed due to: \(error.localizedDescription)"
+        }
+    }
 }

--- a/Sources/OJP/Services/LocationInformation.swift
+++ b/Sources/OJP/Services/LocationInformation.swift
@@ -21,6 +21,6 @@ class LocationInformation {
 
         // sort and return
 
-        throw OJPSDKError.notImplemented
+        throw OJPSDKError.notImplemented()
     }
 }

--- a/Tests/OJPTests/OjpSDKTests.swift
+++ b/Tests/OJPTests/OjpSDKTests.swift
@@ -161,16 +161,15 @@ final class OjpSDKTests: XCTestCase {
         let mock = LoadingStrategy.mock { _ in
             throw URLError(.badServerResponse)
         }
-        let ojpSDK = OJP(loadingStrategy: mock)
-
         do {
+            let ojpSDK = OJP(loadingStrategy: mock)
             _ = try await ojpSDK.requestLocations(from: "bla")
-            XCTFail()
         } catch OJPSDKError.loadingFailed {
-            XCTAssertTrue(true)
-        } catch {
-            XCTFail()
+            XCTAssert(true)
+            return
         }
+
+        XCTFail()
     }
 
     func testLoader() async throws {


### PR DESCRIPTION
- Error now conforms to LocalizedError
- `.notImplemented` gets a reference to file and line number where the error is thrown