### PR TITLE
Undo optional geoposition

### DIFF
--- a/Sources/OJP/GeoHelpers.swift
+++ b/Sources/OJP/GeoHelpers.swift
@@ -30,7 +30,7 @@ enum GeoHelpers {
 
     public static func sort<T: GeoAware>(geoAwareObjects: [T], from point: Point) -> [NearbyObject<T>] {
         var nearbyObjects = geoAwareObjects.map { geoAwareObject in
-            let distance = GeoHelpers.calculateDistance(lon1: point.long, lat1: point.lat, lon2: geoAwareObject.coords.long, lat2: geoAwareObject.coords.lat)
+            let distance = GeoHelpers.calculateDistance(lon1: point.long, lat1: point.lat, lon2: geoAwareObject.geoPosition.longitude, lat2: geoAwareObject.geoPosition.latitude)
             return NearbyObject(object: geoAwareObject, distance: distance)
         }
 

--- a/Sources/OJP/Models/Geo.swift
+++ b/Sources/OJP/Models/Geo.swift
@@ -35,5 +35,5 @@ public struct NearbyObject<T> {
 }
 
 public protocol GeoAware {
-    var coords: Point { get }
+    var geoPosition: OJPv2.GeoPosition { get }
 }

--- a/Sources/OJP/Models/OJPv2+Extensions.swift
+++ b/Sources/OJP/Models/OJPv2+Extensions.swift
@@ -29,9 +29,8 @@ public extension OJPv2.Mode {
 }
 
 extension OJPv2.PlaceResult: GeoAware {
-    public var coords: Point {
-        guard let geoPosition = place.geoPosition else { return (long: COORDINATE_FALLBACK, lat: COORDINATE_FALLBACK) }
-        return (long: geoPosition.longitude, lat: geoPosition.latitude)
+    public var geoPosition: OJPv2.GeoPosition {
+        place.geoPosition
     }
 }
 

--- a/Sources/OJP/Models/OJPv2+LocationInformation.swift
+++ b/Sources/OJP/Models/OJPv2+LocationInformation.swift
@@ -84,8 +84,8 @@ public extension OJPv2 {
 
     struct Place: Codable {
         public let placeType: PlaceType
-        public let name: Name?
-        public let geoPosition: GeoPosition?
+        public let name: Name
+        public let geoPosition: GeoPosition
         public let modes: [Mode]
 
         public enum CodingKeys: String, CodingKey {
@@ -97,8 +97,8 @@ public extension OJPv2 {
         public init(from decoder: any Decoder) throws {
             placeType = try PlaceType(from: decoder)
             let container = try decoder.container(keyedBy: StrippedPrefixCodingKey.self)
-            name = try? container.decode(Name.self, forKey: StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.name))
-            geoPosition = try? container.decode(GeoPosition.self, forKey: StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.geoPosition))
+            name = try container.decode(Name.self, forKey: StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.name))
+            geoPosition = try container.decode(GeoPosition.self, forKey: StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.geoPosition))
             modes = try container.decode([Mode].self, forKey: StrippedPrefixCodingKey.stripPrefix(fromKey: CodingKeys.modes))
         }
     }

--- a/Tests/OJPTests/OjpSDKTests.swift
+++ b/Tests/OJPTests/OjpSDKTests.swift
@@ -43,7 +43,7 @@ final class OjpSDKTests: XCTestCase {
 
         let nearbyPlaceResult = nearbyStations.first!.object
 
-        let nearbyStopName = nearbyPlaceResult.place.name!.text
+        let nearbyStopName = nearbyPlaceResult.place.name.text
         let expectedStopName = "Bern (Bern)"
         XCTAssert(nearbyStopName == expectedStopName, "Expected '\(expectedStopName)' got '\(nearbyStopName)' instead")
 
@@ -233,7 +233,7 @@ final class OjpSDKTests: XCTestCase {
             }
             print("places:")
             for placeResult in locationInformation.placeResults {
-                print(placeResult.place.name!.text)
+                print(placeResult.place.name.text)
             }
         }
 

--- a/Tests/OJPTests/Resources/lir-minimum-response.xml
+++ b/Tests/OJPTests/Resources/lir-minimum-response.xml
@@ -22,13 +22,13 @@
 <!--              </PrivateCode>-->
 <!--              <TopographicPlaceRef>23006351:1</TopographicPlaceRef>-->
             </StopPlace>
-<!--            <Name>
+            <Name>
               <Text xml:lang="de">Bern (Bern)</Text>
-            </Name>-->
-<!--            <GeoPosition>
+            </Name>
+            <GeoPosition>
               <siri:Longitude>7.43913</siri:Longitude>
               <siri:Latitude>46.94883</siri:Latitude>
-            </GeoPosition>-->
+            </GeoPosition>
           </Place>
           <Complete>true</Complete>
 <!--          <Probability>1</Probability>-->


### PR DESCRIPTION
GeoPosition and Name won't be optional in the future. This reverts the work around from #23 

Related to https://github.com/openTdataCH/ojp-sdk/issues/20