### PR TITLE
rename locations with placeResults, fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,25 +51,26 @@ let ojpSdk = OJP(loadingStrategy: .http(apiConfiguration))
 
 ### Basic Usage
 
-Get a list of Locations from a keyword.
+Get a list of PlaceResults from a keyword.
 
 ``` swift
 import OJP
         
 // get only stops
-let stops = try await ojpSdk.requestLocations(from: "Bern", restrictions: [.stop])
+let stops = try await ojpSdk.requestPlaceResults(from: "Bern", restrictions: .init(type: [.stop]))
+
 
         
 // get stops and addresses
-let addresses = try await ojpSdk.requestLocations(from: "Bern", restrictions: [.address, .stop])
+let addresses = try await ojpSdk.requestPlaceResults(from: "Bern", restrictions: .init(type: [.stop, .address]))
 ```
 
-Get a list of Locations around a place with longitude and latitude
+Get a list of PlaceResults around a place with longitude and latitude
 
 ``` swift
 import OJP
 
-let nearbyLocations = try await ojpSdk.requestLocations(from: Point(long: 5.6, lat: 2.3))
+let nearbyStops = try await ojpSdk.requestPlaceResults(from: Point(long: 5.6, lat: 2.3), restrictions: .init(type: [.stop])
 ```
 
 ## Sample App

--- a/SampleApp/OJPSampleApp/LocationSearchByNameView.swift
+++ b/SampleApp/OJPSampleApp/LocationSearchByNameView.swift
@@ -115,7 +115,7 @@ struct LocationSearchByNameView: View {
                 let ojp = OJP.configured
                 let t = Task {
                     do {
-                        results = try await ojp.requestLocations(from: inputName, restrictions: placeParam)
+                        results = try await ojp.requestPlaceResults(from: inputName, restrictions: placeParam)
                         print(results)
                     } catch {
                         print(error)

--- a/Sources/OJP/OJP.swift
+++ b/Sources/OJP/OJP.swift
@@ -58,10 +58,10 @@ public class OJP {
         return decoder
     }
 
-    /// Request a list of Locations based on the given geographical point
+    /// Request a list of PlaceResults based on the given geographical point
     /// - Parameter coordinates: a geo point with longitude and latitude
-    /// - Returns: List of Locations sorted by the nearest point
-    public func requestLocations(from coordinates: Point) async throws -> [NearbyObject<OJPv2.PlaceResult>] {
+    /// - Returns: List of PlaceResults sorted by the nearest point
+    public func requestPlaceResults(from coordinates: Point) async throws -> [NearbyObject<OJPv2.PlaceResult>] {
         let ojp = locationInformationRequest.requestWithBox(centerLongitude: coordinates.long, centerLatitude: coordinates.lat, boxWidth: 1000.0)
 
         let serviceDelivery = try await request(with: ojp).serviceDelivery
@@ -74,11 +74,11 @@ public class OJP {
         return nearbyObjects
     }
 
-    /// Request a list of Locations based on the given search term
+    /// Request a list of PlaceResults based on the given search term
     /// - Parameter searchTerm: The given term
     /// - Parameter restrictions: filter with a place param
-    /// - Returns: List of Locations that contains the search term
-    public func requestLocations(from searchTerm: String, restrictions: OJPv2.PlaceParam) async throws -> [OJPv2.PlaceResult] {
+    /// - Returns: List of PlaceResults that contains the search term
+    public func requestPlaceResults(from searchTerm: String, restrictions: OJPv2.PlaceParam) async throws -> [OJPv2.PlaceResult] {
         let ojp = locationInformationRequest.requestWithSearchTerm(searchTerm, restrictions: restrictions)
 
         let serviceDelivery = try await request(with: ojp).serviceDelivery

--- a/Tests/OJPTests/OjpSDKTests.swift
+++ b/Tests/OJPTests/OjpSDKTests.swift
@@ -39,7 +39,7 @@ final class OjpSDKTests: XCTestCase {
         }
 
         let ojpSdk = OJP(loadingStrategy: .mock(mockLoader))
-        let nearbyStations = try await ojpSdk.requestLocations(from: (long: 7.452178, lat: 46.948474))
+        let nearbyStations = try await ojpSdk.requestPlaceResults(from: (long: 7.452178, lat: 46.948474))
 
         let nearbyPlaceResult = nearbyStations.first!.object
 
@@ -175,7 +175,7 @@ final class OjpSDKTests: XCTestCase {
         let ojpSDK = OJP(loadingStrategy: mock)
 
         do {
-            _ = try await ojpSDK.requestLocations(from: "bla", restrictions: .init(type: [.stop]))
+            _ = try await ojpSDK.requestPlaceResults(from: "bla", restrictions: .init(type: [.stop]))
             XCTFail()
         } catch let OJPSDKError.unexpectedHTTPStatus(statusCode) {
             XCTAssert(statusCode == 400)
@@ -190,7 +190,7 @@ final class OjpSDKTests: XCTestCase {
         }
         do {
             let ojpSDK = OJP(loadingStrategy: mock)
-            _ = try await ojpSDK.requestLocations(from: "bla", restrictions: .init(type: [.stop]))
+            _ = try await ojpSDK.requestPlaceResults(from: "bla", restrictions: .init(type: [.stop]))
         } catch OJPSDKError.loadingFailed {
             XCTAssert(true)
             return

--- a/Tests/OJPTests/SystemTests.swift
+++ b/Tests/OJPTests/SystemTests.swift
@@ -17,7 +17,7 @@ final class SystemTests: XCTestCase {
     func testFetchStations() async throws {
         let ojpSdk = OJP(loadingStrategy: .http(.int))
 
-        let stations = try await ojpSdk.requestLocations(from: "Bern", restrictions: .init(type: [.stop]))
+        let stations = try await ojpSdk.requestPlaceResults(from: "Bern", restrictions: .init(type: [.stop]))
 
         XCTAssert(!stations.isEmpty)
     }
@@ -25,7 +25,7 @@ final class SystemTests: XCTestCase {
     func testFetchNearbyStations() async throws {
         let ojpSdk = OJP(loadingStrategy: .http(.int))
 
-        let nearbyStations = try await ojpSdk.requestLocations(from: (long: 7.452178, lat: 46.948474))
+        let nearbyStations = try await ojpSdk.requestPlaceResults(from: (long: 7.452178, lat: 46.948474))
 
         XCTAssert(!nearbyStations.isEmpty)
     }


### PR DESCRIPTION
Rename the methods like in the android SDK (after discussion with Deniz).

Change in Readme and in the Demo App.