### PR TITLE
Remove SwiftHelper.formattedDate, use iso8601 instead

### DIFF
--- a/Sources/OJP/OJPHelpers.swift
+++ b/Sources/OJP/OJPHelpers.swift
@@ -24,14 +24,6 @@ public enum DepArrTime {
 }
 
 enum OJPHelpers {
-    static func formattedDate(date: Date = Date()) -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'" // ISO 8601 format
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0) // Set timezone to UTC
-
-        let dateF = dateFormatter.string(from: date)
-        return dateF
-    }
 
     class TripRequest {
         init(requesterReference: String) {


### PR DESCRIPTION
formattedDate is unused, as we always use `Date` types and the .iso8601 date formatter