### PR TITLE
Support PlaceRefChoice in LocationInformationRequests

### DIFF
--- a/Sources/OJP/OJP.swift
+++ b/Sources/OJP/OJP.swift
@@ -86,6 +86,18 @@ public class OJP {
         return locationInformationDelivery.placeResults
     }
 
+    public func requestPlaceResults(placeRef: OJPv2.PlaceRefChoice, restrictions: OJPv2.PlaceParam) async throws -> [OJPv2.PlaceResult] {
+        let ojp = locationInformationRequest.request(with: placeRef, restrictions: restrictions)
+
+        let serviceDelivery = try await request(with: ojp).serviceDelivery
+
+        guard case let .locationInformation(locationInformationDelivery) = serviceDelivery.delivery else {
+            throw OJPSDKError.unexpectedEmpty
+        }
+
+        return locationInformationDelivery.placeResults
+    }
+
     public func requestTrips(from: OJPv2.PlaceRefChoice, to: OJPv2.PlaceRefChoice, via: [OJPv2.PlaceRefChoice]? = nil, at: DepArrTime = .departure(Date()), params: OJPv2.TripParams) async throws -> [OJPv2.TripResult] {
         let ojp = tripRequest.requestTrips(from: from, to: to, via: via, at: at, params: params)
 

--- a/Sources/OJP/OJPHelpers.swift
+++ b/Sources/OJP/OJPHelpers.swift
@@ -81,11 +81,30 @@ enum OJPHelpers {
             let geoRestriction = OJPv2.GeoRestriction(rectangle: rectangle)
             let restrictions = OJPv2.PlaceParam(type: [.stop], numberOfResults: numberOfResults, includePtModes: true)
 
-            let locationInformationRequest = OJPv2.LocationInformationRequest(requestTimestamp: requestTimestamp, initialInput: OJPv2.InitialInput(geoRestriction: geoRestriction, name: nil), restrictions: restrictions)
+            let locationInformationRequest = OJPv2.LocationInformationRequest(requestTimestamp: requestTimestamp, input: .initialInput(OJPv2.InitialInput(geoRestriction: geoRestriction, name: nil)), restrictions: restrictions)
 
             let ojp = OJPv2(request: OJPv2.Request(serviceRequest: OJPv2.ServiceRequest(requestTimestamp: requestTimestamp, requestorRef: requesterReference, locationInformationRequest: locationInformationRequest, tripRequest: nil)), response: nil)
 
             return ojp
+        }
+
+        public func request(with placeRef: OJPv2.PlaceRefChoice, restrictions: OJPv2.PlaceParam) -> OJPv2 {
+            let lir = OJPv2.LocationInformationRequest(
+                requestTimestamp: Date(),
+                input: .placeRef(placeRef),
+                restrictions: restrictions
+            )
+            return OJPv2(
+                request: OJPv2.Request(
+                    serviceRequest: OJPv2.ServiceRequest(
+                        requestTimestamp: Date(),
+                        requestorRef: requesterReference,
+                        locationInformationRequest: lir,
+                        tripRequest: nil
+                    )
+                ),
+                response: nil
+            )
         }
 
         /// Creates a new OJP LocationInformationRequest with bounding box around a center coordinate.
@@ -130,7 +149,7 @@ enum OJPHelpers {
         public func requestWithSearchTerm(_ name: String, restrictions: OJPv2.PlaceParam) -> OJPv2 {
             let requestTimestamp = Date()
 
-            let locationInformationRequest = OJPv2.LocationInformationRequest(requestTimestamp: requestTimestamp, initialInput: OJPv2.InitialInput(geoRestriction: nil, name: name), restrictions: restrictions)
+            let locationInformationRequest = OJPv2.LocationInformationRequest(requestTimestamp: requestTimestamp, input: .initialInput(OJPv2.InitialInput(geoRestriction: nil, name: name)), restrictions: restrictions)
 
             // TODO: - avoid duplication (share this block with "requestWith(bbox: Geo.Bbox")
             let ojp = OJPv2(request: OJPv2.Request(serviceRequest: OJPv2.ServiceRequest(requestTimestamp: requestTimestamp, requestorRef: requesterReference, locationInformationRequest: locationInformationRequest, tripRequest: nil)), response: nil)

--- a/Tests/OJPTests/LocationRequestTests.swift
+++ b/Tests/OJPTests/LocationRequestTests.swift
@@ -7,8 +7,9 @@ final class LocationRequestTests: XCTestCase {
     func testGeoRestrictionHelpers() throws {
         // BBOX with Kleine Schanze as center + width / height of 1km
         let ojp = locationInformationRequest.requestWithBox(centerLongitude: 7.44029, centerLatitude: 46.94578, boxWidth: 1000.0)
-
-        if let rectangle = ojp.request?.serviceRequest.locationInformationRequest!.initialInput.geoRestriction?.rectangle {
+        guard case let .initialInput(input) = ojp.request?.serviceRequest.locationInformationRequest!.input else { return XCTFail("invalid input type")
+        }
+        if let rectangle = input.geoRestriction?.rectangle {
             XCTAssertTrue(rectangle.lowerRight.longitude > rectangle.upperLeft.longitude)
             XCTAssertTrue(rectangle.upperLeft.latitude > rectangle.lowerRight.latitude)
 
@@ -18,7 +19,6 @@ final class LocationRequestTests: XCTestCase {
             XCTAssertTrue(rectangle.lowerRight.latitude == 46.941283, "Unexpected lowerRight.latitude \(rectangle.lowerRight.latitude)")
         } else {
             XCTFail("Cant compute geoRestriction rectangle")
-            print(ojp)
         }
     }
 

--- a/Tests/OJPTests/SystemTests.swift
+++ b/Tests/OJPTests/SystemTests.swift
@@ -30,6 +30,14 @@ final class SystemTests: XCTestCase {
         XCTAssert(!nearbyStations.isEmpty)
     }
 
+    func testFetchStationByDidok() async throws {
+        let ojpSdk = OJP(loadingStrategy: .http(.int))
+
+        let nearbyStations = try await ojpSdk.requestPlaceResults(placeRef: .stopPointRef(.init(stopPointRef: "8507000", name: .init("Bern"))), restrictions: .init(type: [.stop]))
+
+        XCTAssert(!nearbyStations.isEmpty)
+    }
+
     func testFetchTripWithDidoks() async throws {
         let ojpSdk = OJP(loadingStrategy: .http(.int))
 


### PR DESCRIPTION
In order to get concrete additional information (like geo coordinates) for a specific StopPlace, StopPoint, GeoPosition, ... we need a method wich supports [PlaceRef](https://vdvde.github.io/OJP/develop/index.html#PlaceRefGroup) as an option.

[LocationInformationRequestGroup](https://vdvde.github.io/OJP/develop/index.html#LocationInformationRequestGroup)