### PR TITLE
56 decoder has issue with namespace handling when an element name can is in both namespaces

### DIFF
--- a/Sources/OJP/Models/OJPv2+Trip.swift
+++ b/Sources/OJP/Models/OJPv2+Trip.swift
@@ -33,14 +33,14 @@ public extension OJPv2 {
         }
     }
 
-    struct TripResponseContext: Codable {
+    struct TripResponseContext: Codable, Sendable {
         let situations: [SituationTypeChoice]
 
         public enum CodingKeys: String, CodingKey {
             case situations = "Situations"
         }
     }
-    struct Situation: Codable {
+    struct Situation: Codable, Sendable {
         let situation: SituationTypeChoice
 
         public init(from decoder: any Decoder) throws {
@@ -49,7 +49,7 @@ public extension OJPv2 {
     }
 
     /// https://vdvde.github.io/OJP/develop/index.html#SituationsStructure
-    enum SituationTypeChoice: Codable {
+    enum SituationTypeChoice: Codable, Sendable {
         case ptSituation(PTSituation)
         case roadSituation(RoadSituation)
 
@@ -80,8 +80,8 @@ public extension OJPv2 {
         }
     }
 
-    struct PTSituation: Codable {
-        
+    struct PTSituation: Codable, Sendable {
+
         let situationNumber: String
         let validityPeriod: ValidityPeriod
 
@@ -92,7 +92,7 @@ public extension OJPv2 {
     }
 
 
-    struct ValidityPeriod: Codable {
+    struct ValidityPeriod: Codable, Sendable {
         let startTime: Date
         let endTime: Date?
         
@@ -101,7 +101,7 @@ public extension OJPv2 {
             case endTime = "siri:EndTime"
         }
     }
-    struct RoadSituation: Codable {}
+    struct RoadSituation: Codable, Sendable {}
     
     /// [Schema documentation on vdvde.github.io](https://vdvde.github.io/OJP/develop/index.html#TripResultStructure)
     struct TripResult: Codable, Identifiable, Sendable {

--- a/Sources/OJP/OJPDecoder.swift
+++ b/Sources/OJP/OJPDecoder.swift
@@ -27,13 +27,19 @@ struct NamespaceAwareCodingKey: CodingKey {
         self.intValue = intValue
     }
 
-    static func create(from key: CodingKey, ojpNS: String, siriNS: String, mapping: inout [String: String]) -> NamespaceAwareCodingKey {
-        let strippedKey = removeNameSpace(key.stringValue)
+    static func create(from keys: [CodingKey], ojpNS: String, siriNS: String, mapping: inout [String: String]) -> NamespaceAwareCodingKey {
+        let strippedKeys = keys.map { key in removeNameSpace(key.stringValue)
+        }
+        let lookupKey = strippedKeys
+            .filter({ $0 != "0" })
+            .joined(separator: "/")
         // the mapping is needed, as the keyDecodingStrategy could be performed on a already converted key, leading to an invalid new key
-        if let existing = mapping[strippedKey] {
+        print(lookupKey)
+        if let existing = mapping[lookupKey] {
             return NamespaceAwareCodingKey(stringValue: existing)!
         }
-
+        let key = keys.last!
+        let strippedKey = removeNameSpace(key.stringValue)
         if ojpNS.isEmpty && siriNS.isEmpty || key.stringValue.contains("xmlns") {
             // ignore root elements
             return NamespaceAwareCodingKey(stringValue: strippedKey)!
@@ -41,17 +47,17 @@ struct NamespaceAwareCodingKey: CodingKey {
 
         if !ojpNS.isEmpty, key.stringValue.contains(ojpNS) {
             // removes a potential "ojp" namespace to match the the type's CodingKeys
-            mapping[strippedKey] = strippedKey
+            mapping[lookupKey] = strippedKey
             return NamespaceAwareCodingKey(stringValue: removeNameSpace(key.stringValue))!
         }
         if siriNS.isEmpty, !key.stringValue.contains(ojpNS) {
             // adds 'siri:' if it isn't present in the source to match the type's CodingKeys
-            mapping[strippedKey] = "siri:\(key.stringValue)"
+            mapping[lookupKey] = "siri:\(key.stringValue)"
             return NamespaceAwareCodingKey(stringValue: "siri:\(key.stringValue)")!
         }
 
         // keep stringValue as it is
-        mapping[strippedKey] = "\(key.stringValue)"
+        mapping[lookupKey] = "\(key.stringValue)"
         return NamespaceAwareCodingKey(stringValue: key.stringValue)!
     }
 
@@ -70,11 +76,11 @@ enum OJPDecoder {
 
         decoder.dateDecodingStrategy = .iso8601
         decoder.keyDecodingStrategy = .custom { codingPath in
-            guard let codingPath = codingPath.last else { fatalError() }
+            guard let codingPathLast = codingPath.last else { fatalError() }
             // This is a very naive approach to check the used namespaces. Maybe implement a more robust one in the future.
-            if codingPath.stringValue.contains("xmlns:ojp") {
+            if codingPathLast.stringValue.contains("xmlns:ojp") {
                 ojpNameSpace = "ojp:"
-            } else if codingPath.stringValue.contains("xmlns:siri") {
+            } else if codingPathLast.stringValue.contains("xmlns:siri") {
                 siriNameSpace = "siri:"
             }
 

--- a/Sources/OJP/OJPDecoder.swift
+++ b/Sources/OJP/OJPDecoder.swift
@@ -28,13 +28,13 @@ struct NamespaceAwareCodingKey: CodingKey {
     }
 
     static func create(from keys: [CodingKey], ojpNS: String, siriNS: String, mapping: inout [String: String]) -> NamespaceAwareCodingKey {
-        let strippedKeys = keys.map { key in removeNameSpace(key.stringValue)
-        }
+        let strippedKeys = keys.map { key in removeNameSpace(key.stringValue) }
         let lookupKey = strippedKeys
-            .filter({ $0 != "0" })
+            .filter({ Int($0) == nil }) // ignore positional keys
             .joined(separator: "/")
-        // the mapping is needed, as the keyDecodingStrategy could be performed on a already converted key, leading to an invalid new key
-        print(lookupKey)
+
+        // the mapping is needed, as the keyDecodingStrategy could be performed on a already converted key, leading to an invalid new key.
+        // as elements could turn up both in siri and ojp namespace, we need the whole list of coding keys. See https://github.com/openTdataCH/ojp-ios/issues/56
         if let existing = mapping[lookupKey] {
             return NamespaceAwareCodingKey(stringValue: existing)!
         }

--- a/Tests/OJPTests/Resources/tr/situations/tr-berne-nimes.xml
+++ b/Tests/OJPTests/Resources/tr/situations/tr-berne-nimes.xml
@@ -1,0 +1,3551 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OJP xmlns:siri="http://www.siri.org.uk/siri" version="2.0"
+    xmlns="http://www.vdv.de/ojp">
+    <OJPResponse>
+        <siri:ServiceDelivery>
+            <siri:ResponseTimestamp>2024-07-03T09:18:00.0948706+02:00</siri:ResponseTimestamp>
+            <siri:ProducerRef>MENTZ</siri:ProducerRef>
+            <OJPTripDelivery>
+                <siri:ResponseTimestamp>2024-07-03T09:18:00.0948721+02:00</siri:ResponseTimestamp>
+                <siri:RequestMessageRef>c2efc597-f5aa-41a0-9a5b-54287286306a</siri:RequestMessageRef>
+                <siri:DefaultLanguage>de</siri:DefaultLanguage>
+                <CalcTime>1929</CalcTime>
+                <TripResponseContext>
+                    <Situations>
+                        <PtSituation>
+                            <siri:CreationTime>2024-06-24T08:13:00Z</siri:CreationTime>
+                            <siri:ParticipantRef>ski-ddip-out-sx_int</siri:ParticipantRef>
+                            <siri:SituationNumber>ch:1:sstid:100001:ed915702-f996-410b-a84b-0fcdf139785f-0</siri:SituationNumber>
+                            <siri:Version>3</siri:Version>
+                            <siri:Source>
+                                <siri:SourceType>other</siri:SourceType>
+                            </siri:Source>
+                            <siri:ValidityPeriod>
+                                <siri:StartTime>2024-06-30T22:00:00Z</siri:StartTime>
+                                <siri:EndTime>2024-07-05T22:00:00Z</siri:EndTime>
+                            </siri:ValidityPeriod>
+                            <siri:AlertCause>unknown</siri:AlertCause>
+                            <siri:UnknownReason>unknown</siri:UnknownReason>
+                            <siri:Priority>3</siri:Priority>
+                            <siri:ScopeType>stopPoint</siri:ScopeType>
+                            <siri:Language>de</siri:Language>
+                            <siri:Affects>
+                                <siri:StopPoints>
+                                    <siri:AffectedStopPoint>
+                                        <siri:StopPointRef>8500218</siri:StopPointRef>
+                                    </siri:AffectedStopPoint>
+                                    <siri:AffectedStopPoint>
+                                        <siri:StopPointRef>8507000</siri:StopPointRef>
+                                    </siri:AffectedStopPoint>
+                                </siri:StopPoints>
+                                <siri:VehicleJourneys />
+                            </siri:Affects>
+                            <siri:Consequences>
+                                <siri:Consequence>
+                                    <siri:Blocking>
+                                        <siri:JourneyPlanner>true</siri:JourneyPlanner>
+                                    </siri:Blocking>
+                                </siri:Consequence>
+                            </siri:Consequences>
+                            <siri:PublishingActions>
+                                <siri:PublishingAction>
+                                    <siri:PassengerInformationAction>
+                                        <siri:RecordedAtTime>0001-01-01T00:00:00</siri:RecordedAtTime>
+                                        <siri:TextualContent>
+                                            <siri:SummaryContent>
+                                                <siri:SummaryText xml:lang="de">Der Bahnverkehr zwischen Olten und Bern ist eingeschränkt.</siri:SummaryText>
+                                            </siri:SummaryContent>
+                                            <siri:ReasonContent>
+                                                <siri:ReasonText xml:lang="de">Der Grund dafür sind Bauarbeiten.</siri:ReasonText>
+                                            </siri:ReasonContent>
+                                            <siri:DescriptionContent />
+                                            <siri:ConsequenceContent>
+                                                <siri:ConsequenceText xml:lang="de">Es ist ein geänderter Fahrplan zu erwarten.</siri:ConsequenceText>
+                                            </siri:ConsequenceContent>
+                                            <siri:RecommendationContent>
+                                                <siri:RecommendationText xml:lang="de">Wir empfehlen, kurz vor jeder Fahrt den Online-Fahrplan zu konsultieren.</siri:RecommendationText>
+                                            </siri:RecommendationContent>
+                                            <siri:DurationContent>
+                                                <siri:DurationText xml:lang="de">Die Einschränkung dauert von 01.07.2024, 00:00 bis 05.07.2024, 23:59.</siri:DurationText>
+                                            </siri:DurationContent>
+                                            <siri:RemarkContent />
+                                        </siri:TextualContent>
+                                    </siri:PassengerInformationAction>
+                                </siri:PublishingAction>
+                            </siri:PublishingActions>
+                        </PtSituation>
+                    </Situations>
+                </TripResponseContext>
+                <TripResult>
+                    <Id>ID-3C516B0B-D2DB-42D2-8784-041D925FC153</Id>
+                    <Trip>
+                        <Id>ID-3C516B0B-D2DB-42D2-8784-041D925FC153</Id>
+                        <Duration>PT15H8M</Duration>
+                        <StartTime>2024-07-02T16:34:00Z</StartTime>
+                        <EndTime>2024-07-03T07:42:00Z</EndTime>
+                        <Transfers>2</Transfers>
+                        <Leg>
+                            <Id>1</Id>
+                            <Duration>PT1H44M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>ch:1:sloid:7000:2:3</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bern</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </EstimatedQuay>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T16:34:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:4100:0:54</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Fribourg/Freiburg</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">4</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T16:55:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T16:56:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:1120:0:860143</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Lausanne</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">4</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T17:41:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T17:43:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>3</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>ch:1:sloid:1008:2:3</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T18:18:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>4</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>interregionalRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">IC</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>728</TrainNumber>
+                                    <siri:LineRef>ojp:91001:D</siri:LineRef>
+                                    <siri:OperatorRef>11</siri:OperatorRef>
+                                    <PublicCode>InterCity</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">IC1</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">IC</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>23</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-02</OperatingDayRef>
+                                    <OriginStopPointRef>ch:1:sloid:7000:2:3</OriginStopPointRef>
+                                    <DestinationStopPointRef>ch:1:sloid:1008:2:3</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Bern</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ch:1:sjyid:100001:728-001</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Ruhezone in 1. Klasse</Text>
+                                        </UserText>
+                                        <Code>A__RZ</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Businesszone in 1. Klasse</Text>
+                                        </UserText>
+                                        <Code>A__BZ</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Gratis-Internet mit der App SBB FreeSurf</Text>
+                                        </UserText>
+                                        <Code>A__FS</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Familienwagen mit Spielplatz</Text>
+                                        </UserText>
+                                        <Code>A__FA</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Restaurant</Text>
+                                        </UserText>
+                                        <Code>A__WR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung möglich</Text>
+                                        </UserText>
+                                        <Code>A___R</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>2</Id>
+                            <Duration>PT4M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8501008</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8501008</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT4M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>3</Id>
+                            <Duration>PT29M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>ch:1:sloid:1008:4:8</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">8</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">8</Text>
+                                    </EstimatedQuay>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T18:29:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegAlight>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T18:58:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>2</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>highSpeedRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>9784</TrainNumber>
+                                    <siri:LineRef>ojp:91048:Y</siri:LineRef>
+                                    <siri:OperatorRef>11</siri:OperatorRef>
+                                    <PublicCode>Train à grande vit.</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">TGV</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>20</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-02</OperatingDayRef>
+                                    <OriginStopPointRef>ch:1:sloid:1008:4:8</OriginStopPointRef>
+                                    <DestinationStopPointRef>8774500</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ch:1:sjyid:100001:9784-005</JourneyRef>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>4</Id>
+                            <Duration>PT4M</Duration>
+                            <TransferLeg>
+                                <TransferType>remainInVehicle</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT4M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>5</Id>
+                            <Duration>PT2H40M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:02:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774300</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bourg-en-Bresse</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:49:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:52:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>8768600</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Paris Gare de Lyon</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T21:42:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>3</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>highSpeedRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>9784</TrainNumber>
+                                    <siri:LineRef>ojp:91622:E</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Train à grande vit.</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">622E</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>20</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>H</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-02</OperatingDayRef>
+                                    <OriginStopPointRef>8774500</OriginStopPointRef>
+                                    <DestinationStopPointRef>8768600</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Paris Gare de Lyon</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-622-E-j24-1-13-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Türen schliessen zwei Minuten vor Abfahrt</Text>
+                                        </UserText>
+                                        <Code>A__TA</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung obligatorisch</Text>
+                                        </UserText>
+                                        <Code>A__RR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Globalpreis</Text>
+                                        </UserText>
+                                        <Code>A__GP</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>6</Id>
+                            <Duration>PT15M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8768600</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Paris Gare de Lyon</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8768600</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Paris Gare de Lyon</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT15M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>7</Id>
+                            <Duration>PT3H</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8768600</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Paris Gare de Lyon</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:42:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8776302</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Valence TGV Rhône-Alpes Sud</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T06:53:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T06:56:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>8777500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Nîmes</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T07:42:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>3</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>highSpeedRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>6221</TrainNumber>
+                                    <siri:LineRef>ojp:91631:C</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Train à grande vit.</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">631C</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>20</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>8768600</OriginStopPointRef>
+                                    <DestinationStopPointRef>8777500</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Paris Gare de Lyon</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Nîmes</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-631-C-j24-1-300-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Türen schliessen zwei Minuten vor Abfahrt</Text>
+                                        </UserText>
+                                        <Code>A__TA</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung obligatorisch</Text>
+                                        </UserText>
+                                        <Code>A__RR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Globalpreis</Text>
+                                        </UserText>
+                                        <Code>A__GP</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                    </Trip>
+                </TripResult>
+                <TripResult>
+                    <Id>ID-641A4042-0DBD-4DBF-9888-490714DA96F9</Id>
+                    <Trip>
+                        <Id>ID-641A4042-0DBD-4DBF-9888-490714DA96F9</Id>
+                        <Duration>PT13H30M</Duration>
+                        <StartTime>2024-07-02T16:34:00Z</StartTime>
+                        <EndTime>2024-07-03T06:04:00Z</EndTime>
+                        <Transfers>3</Transfers>
+                        <Leg>
+                            <Id>1</Id>
+                            <Duration>PT1H44M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>ch:1:sloid:7000:2:3</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bern</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </EstimatedQuay>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T16:34:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:4100:0:54</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Fribourg/Freiburg</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">4</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T16:55:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T16:56:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:1120:0:860143</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Lausanne</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">4</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T17:41:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T17:43:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>3</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>ch:1:sloid:1008:2:3</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T18:18:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>4</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>interregionalRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">IC</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>728</TrainNumber>
+                                    <siri:LineRef>ojp:91001:D</siri:LineRef>
+                                    <siri:OperatorRef>11</siri:OperatorRef>
+                                    <PublicCode>InterCity</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">IC1</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">IC</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>23</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-02</OperatingDayRef>
+                                    <OriginStopPointRef>ch:1:sloid:7000:2:3</OriginStopPointRef>
+                                    <DestinationStopPointRef>ch:1:sloid:1008:2:3</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Bern</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ch:1:sjyid:100001:728-001</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Ruhezone in 1. Klasse</Text>
+                                        </UserText>
+                                        <Code>A__RZ</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Businesszone in 1. Klasse</Text>
+                                        </UserText>
+                                        <Code>A__BZ</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Gratis-Internet mit der App SBB FreeSurf</Text>
+                                        </UserText>
+                                        <Code>A__FS</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Familienwagen mit Spielplatz</Text>
+                                        </UserText>
+                                        <Code>A__FA</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Restaurant</Text>
+                                        </UserText>
+                                        <Code>A__WR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung möglich</Text>
+                                        </UserText>
+                                        <Code>A___R</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>2</Id>
+                            <Duration>PT4M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8501008</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8501008</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT4M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>3</Id>
+                            <Duration>PT29M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>ch:1:sloid:1008:4:8</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">8</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">8</Text>
+                                    </EstimatedQuay>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T18:29:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegAlight>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T18:58:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>2</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>highSpeedRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>9784</TrainNumber>
+                                    <siri:LineRef>ojp:91048:Y</siri:LineRef>
+                                    <siri:OperatorRef>11</siri:OperatorRef>
+                                    <PublicCode>Train à grande vit.</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">TGV</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>20</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-02</OperatingDayRef>
+                                    <OriginStopPointRef>ch:1:sloid:1008:4:8</OriginStopPointRef>
+                                    <DestinationStopPointRef>8774500</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ch:1:sjyid:100001:9784-005</JourneyRef>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>4</Id>
+                            <Duration>PT4M</Duration>
+                            <TransferLeg>
+                                <TransferType>remainInVehicle</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT4M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>5</Id>
+                            <Duration>PT47M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:02:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegAlight>
+                                    <siri:StopPointRef>8774300</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bourg-en-Bresse</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:49:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>2</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>highSpeedRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>9784</TrainNumber>
+                                    <siri:LineRef>ojp:91622:E</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Train à grande vit.</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">622E</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>20</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>H</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-02</OperatingDayRef>
+                                    <OriginStopPointRef>8774500</OriginStopPointRef>
+                                    <DestinationStopPointRef>8774300</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Bourg-en-Bresse</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-622-E-j24-1-13-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Türen schliessen zwei Minuten vor Abfahrt</Text>
+                                        </UserText>
+                                        <Code>A__TA</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung obligatorisch</Text>
+                                        </UserText>
+                                        <Code>A__RR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Globalpreis</Text>
+                                        </UserText>
+                                        <Code>A__GP</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>6</Id>
+                            <Duration>PT5M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8774300</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Bourg-en-Bresse</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8774300</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Bourg-en-Bresse</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT5M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>7</Id>
+                            <Duration>PT1H1M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8774300</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bourg-en-Bresse</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T03:17:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8772379</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Servas - Lent</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T03:23:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T03:24:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8772378</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Saint-Paul-de-Varax</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T03:28:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T03:29:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>3</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8772376</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Marlieux - Châtillon</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T03:34:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T03:35:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>4</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8772375</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Villars-les-Dombes</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T03:41:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T03:42:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>5</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8772374</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Saint-Marcel en Dombes</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T03:47:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T03:48:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>6</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8772373</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Saint-André-de-Corcy</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T03:51:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T03:52:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>7</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8772372</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Mionnay</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T03:56:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T03:57:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>8</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8772371</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Les Échets</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T04:00:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:01:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>9</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8772370</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Sathonay - Rillieux</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T04:07:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:10:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>10</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T04:18:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>11</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>regionalRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TER</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>887411</TrainNumber>
+                                    <siri:LineRef>ojp:91C23:_x0020_</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Train Express Regional</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">C23</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TER</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>24</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>8774300</OriginStopPointRef>
+                                    <DestinationStopPointRef>8772319</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Bourg-en-Bresse</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-C23-_-j24-1-179-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>8</Id>
+                            <Duration>PT10M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT10M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>9</Id>
+                            <Duration>PT1H24M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:40:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8776302</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Valence TGV Rhône-Alpes Sud</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T05:15:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T05:19:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>8777500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Nîmes</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T06:04:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>3</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>highSpeedRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>6821</TrainNumber>
+                                    <siri:LineRef>ojp:9141G:_x0020_</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Train à grande vit.</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">041G</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>20</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>8772319</OriginStopPointRef>
+                                    <DestinationStopPointRef>8777500</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Nîmes</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-41G-_-j24-1-78-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Türen schliessen zwei Minuten vor Abfahrt</Text>
+                                        </UserText>
+                                        <Code>A__TA</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung obligatorisch</Text>
+                                        </UserText>
+                                        <Code>A__RR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Globalpreis</Text>
+                                        </UserText>
+                                        <Code>A__GP</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                    </Trip>
+                </TripResult>
+                <TripResult>
+                    <Id>ID-3C3B3088-8853-4A14-B77E-2D4730BFD5DD</Id>
+                    <Trip>
+                        <Id>ID-3C3B3088-8853-4A14-B77E-2D4730BFD5DD</Id>
+                        <Duration>PT14H8M</Duration>
+                        <StartTime>2024-07-02T17:34:00Z</StartTime>
+                        <EndTime>2024-07-03T07:42:00Z</EndTime>
+                        <Transfers>5</Transfers>
+                        <Leg>
+                            <Id>1</Id>
+                            <Duration>PT1H44M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>ch:1:sloid:7000:2:3</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bern</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </EstimatedQuay>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T17:34:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:4100:0:54</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Fribourg/Freiburg</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">4</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T17:55:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T17:56:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:1120:0:860143</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Lausanne</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">4</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T18:41:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T18:43:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>3</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>ch:1:sloid:1008:2:3</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:18:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>4</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>interregionalRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">IC</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>730</TrainNumber>
+                                    <siri:LineRef>ojp:91001:D</siri:LineRef>
+                                    <siri:OperatorRef>11</siri:OperatorRef>
+                                    <PublicCode>InterCity</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">IC1</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">IC</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>23</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-02</OperatingDayRef>
+                                    <OriginStopPointRef>ch:1:sloid:7000:2:3</OriginStopPointRef>
+                                    <DestinationStopPointRef>ch:1:sloid:1008:2:3</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Bern</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ch:1:sjyid:100001:730-001</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Ruhezone in 1. Klasse</Text>
+                                        </UserText>
+                                        <Code>A__RZ</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Businesszone in 1. Klasse</Text>
+                                        </UserText>
+                                        <Code>A__BZ</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Gratis-Internet mit der App SBB FreeSurf</Text>
+                                        </UserText>
+                                        <Code>A__FS</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Familienwagen mit Spielplatz</Text>
+                                        </UserText>
+                                        <Code>A__FA</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Restaurant</Text>
+                                        </UserText>
+                                        <Code>A__WR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung möglich</Text>
+                                        </UserText>
+                                        <Code>A___R</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>2</Id>
+                            <Duration>PT5M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8501008</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8592801</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève, Chantepoulet</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT5M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>3</Id>
+                            <Duration>PT5M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>ch:1:sloid:92801:0:413027</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève, Chantepoulet</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">Q</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">Q</Text>
+                                    </EstimatedQuay>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">PLATFORM_NOT_WHEELCHAIR_ACCESSIBLE</Text>
+                                    </NameSuffix>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:24:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:92864:0:294522</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève, Mont-Blanc</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">PLATFORM_ACCESS_WITH_ASSISTANCE</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">G</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:25:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:25:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:92856:0:780275</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève, Métropole</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">PLATFORM_ACCESS_WITH_ASSISTANCE</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">N</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:28:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:28:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>3</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>ch:1:sloid:87061:0:202187</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève, Rive</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">PLATFORM_ACCESS_WITH_ASSISTANCE</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">K</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:29:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>4</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>bus</PtMode>
+                                        <siri:BusSubmode>localBus</siri:BusSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Bus</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">B</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>312246</TrainNumber>
+                                    <siri:LineRef>ojp:92009:L</siri:LineRef>
+                                    <siri:OperatorRef>881</siri:OperatorRef>
+                                    <PublicCode>Bus</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">9</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Bus</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">B</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>29</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-02</OperatingDayRef>
+                                    <OriginStopPointRef>ch:1:sloid:92801:0:413027</OriginStopPointRef>
+                                    <DestinationStopPointRef>ch:1:sloid:87061:0:202187</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Genève, Chantepoulet</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Genève, Rive</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-92-9-L-j24-1-1952-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>4</Id>
+                            <Duration>PT2M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8587061</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève, Rive</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8587061</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève, Rive</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT2M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>5</Id>
+                            <Duration>PT21M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>ch:1:sloid:87061:0:681082</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève, Rive</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">B</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">B</Text>
+                                    </EstimatedQuay>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">PLATFORM_ACCESS_WITHOUT_ASSISTANCE</Text>
+                                    </NameSuffix>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:36:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:92910:0:151460</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève, Terrassière</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">PLATFORM_NOT_WHEELCHAIR_ACCESSIBLE</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">T</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:37:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:37:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:92924:0:300395</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève, Villereuse</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">X</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:38:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:38:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>3</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:92829:0:618983</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève-Eaux-Vives, gare</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">PLATFORM_ACCESS_WITHOUT_ASSISTANCE</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">B</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:40:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:40:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>4</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:92778:0:690317</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève, Amandolier</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">J</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:41:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:41:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>5</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:92833:0:4314</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Chêne-Bougeries, Grange-Canal</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">M</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:43:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:43:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>6</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:92694:0:980228</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Chêne-Bougeries, Grangettes</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">Q</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:44:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:44:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>7</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:92706:0:172187</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Chêne-Bougeries,Grange-Falquet</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">Y</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:45:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:45:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>8</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:92713:0:649381</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Chêne-Bourg, Place Favre</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">PLATFORM_NOT_WHEELCHAIR_ACCESSIBLE</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">I</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:47:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:47:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>9</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:92709:0:442857</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Chêne-Bourg, Peillonnex</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">K</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:48:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:48:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>10</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:93112:0:326217</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Thônex, Graveson</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">Q</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:49:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:49:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>11</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:93118:0:435432</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Thônex, Moillesulaz</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">D</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:51:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:51:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>12</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:1400015:0:843922</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Gaillard, Libération</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">B</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:52:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:52:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>13</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:1400017:0:753127</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Gaillard, Millet</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">M</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:53:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:53:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>14</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:1400019:0:11853</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Ambilly, Croix-d'Ambilly</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">B</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:55:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T19:55:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>15</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>1400021</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Annemasse, Parc Montessuit</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">M</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T19:57:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>16</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>tram</PtMode>
+                                        <siri:TramSubmode>cityTram</siri:TramSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Tram</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">T</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>331610</TrainNumber>
+                                    <siri:LineRef>ojp:91017:D</siri:LineRef>
+                                    <siri:OperatorRef>881</siri:OperatorRef>
+                                    <PublicCode>Tram</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">17</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Tram</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">T</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>2</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>H</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-02</OperatingDayRef>
+                                    <OriginStopPointRef>ch:1:sloid:87061:0:681082</OriginStopPointRef>
+                                    <DestinationStopPointRef>1400021</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Genève, Rive</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Annemasse, Parc Montessuit</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-17-D-j24-1-1439-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>6</Id>
+                            <Duration>PT13M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>1400021</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Annemasse, Parc Montessuit</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8774549</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Annemasse</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT13M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>7</Id>
+                            <Duration>PT1H</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8774549</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Annemasse</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T20:20:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774620</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Pringy (Haute-Savoie)</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T21:10:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-02T21:10:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>8774600</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Annecy</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-02T21:20:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>3</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>bus</PtMode>
+                                        <siri:BusSubmode>localBus</siri:BusSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Bus</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">B</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>49553</TrainNumber>
+                                    <siri:LineRef>ojp:920L2:_x0020_</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Bus</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">L2</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Bus</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">B</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>29</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-02</OperatingDayRef>
+                                    <OriginStopPointRef>8774549</OriginStopPointRef>
+                                    <DestinationStopPointRef>8774600</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Annemasse</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Annecy</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-92-L2-_-j24-1-62-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>8</Id>
+                            <Duration>PT5M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8774600</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Annecy</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8774600</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Annecy</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT5M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>9</Id>
+                            <Duration>PT2H50M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8774600</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Annecy</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T03:43:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774614</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Rumilly</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T03:59:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:01:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774611</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Albens</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T04:08:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:10:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>3</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774610</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Grésy-sur-Aix</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T04:16:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:18:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>4</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774113</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Aix-les-Bains-le-Revard</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T04:23:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:26:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>5</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774100</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Chambéry-Challes-les-Eaux</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T04:37:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:40:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>6</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774118</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Montmélian</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T04:49:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:50:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>7</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774749</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Pontcharra-sur-Bréda-Allevard</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T04:57:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:58:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>8</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774740</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Grenoble Universités-Gières</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T05:17:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T05:18:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>9</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774700</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Grenoble</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T05:27:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T05:30:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>10</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774732</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Moirans</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T05:41:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T05:43:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>11</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8776175</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Tullins-Fures</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T05:48:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T05:50:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>12</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8776171</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">St-Marcellin (Isère)</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T06:03:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T06:05:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>13</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8776168</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Saint-Hilaire-St-Nazaire</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T06:13:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T06:14:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>14</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8776165</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Romans - Bourg-de-Péage</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T06:25:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T06:27:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>15</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>8776302</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Valence TGV Rhône-Alpes Sud</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T06:33:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>16</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>regionalRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TER</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>17506</TrainNumber>
+                                    <siri:LineRef>ojp:91K21:_x0020_</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Train Express Regional</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">K21</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TER</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>24</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>H</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>8774600</OriginStopPointRef>
+                                    <DestinationStopPointRef>8776302</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Annecy</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Valence TGV Rhône-Alpes Sud</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-K21-_-j24-1-69-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>10</Id>
+                            <Duration>PT15M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8776302</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Valence TGV Rhône-Alpes Sud</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8776302</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Valence TGV Rhône-Alpes Sud</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT15M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>11</Id>
+                            <Duration>PT46M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8776302</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Valence TGV Rhône-Alpes Sud</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T06:56:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegAlight>
+                                    <siri:StopPointRef>8777500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Nîmes</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T07:42:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>2</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>highSpeedRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>6221</TrainNumber>
+                                    <siri:LineRef>ojp:91631:C</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Train à grande vit.</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">631C</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>20</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>8776302</OriginStopPointRef>
+                                    <DestinationStopPointRef>8777500</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Valence TGV Rhône-Alpes Sud</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Nîmes</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-631-C-j24-1-300-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Türen schliessen zwei Minuten vor Abfahrt</Text>
+                                        </UserText>
+                                        <Code>A__TA</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung obligatorisch</Text>
+                                        </UserText>
+                                        <Code>A__RR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Globalpreis</Text>
+                                        </UserText>
+                                        <Code>A__GP</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                    </Trip>
+                </TripResult>
+                <TripResult>
+                    <Id>ID-38E239F9-F84C-4B6B-B004-A2A15E325506</Id>
+                    <Trip>
+                        <Id>ID-38E239F9-F84C-4B6B-B004-A2A15E325506</Id>
+                        <Duration>PT5H47M</Duration>
+                        <StartTime>2024-07-03T04:34:00Z</StartTime>
+                        <EndTime>2024-07-03T10:21:00Z</EndTime>
+                        <Transfers>2</Transfers>
+                        <Leg>
+                            <Id>1</Id>
+                            <Duration>PT1H44M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>ch:1:sloid:7000:4:8</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bern</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">8</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">8</Text>
+                                    </EstimatedQuay>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:34:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:4100:0:54</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Fribourg/Freiburg</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">4</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T04:55:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T04:56:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:1120:0:860143</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Lausanne</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">4</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T05:41:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T05:43:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>3</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>ch:1:sloid:1008:2:3</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </PlannedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T06:18:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>4</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>interregionalRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">IC</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>704</TrainNumber>
+                                    <siri:LineRef>ojp:91001:D</siri:LineRef>
+                                    <siri:OperatorRef>11</siri:OperatorRef>
+                                    <PublicCode>InterCity</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">IC1</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">IC</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>23</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>ch:1:sloid:7000:4:8</OriginStopPointRef>
+                                    <DestinationStopPointRef>ch:1:sloid:1008:2:3</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Bern</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ch:1:sjyid:100001:704-001</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Restaurant</Text>
+                                        </UserText>
+                                        <Code>A__WR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Ruhezone in 1. Klasse</Text>
+                                        </UserText>
+                                        <Code>A__RZ</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Businesszone in 1. Klasse</Text>
+                                        </UserText>
+                                        <Code>A__BZ</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Gratis-Internet mit der App SBB FreeSurf</Text>
+                                        </UserText>
+                                        <Code>A__FS</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Familienwagen mit Spielplatz</Text>
+                                        </UserText>
+                                        <Code>A__FA</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>2</Id>
+                            <Duration>PT4M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8501008</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8501008</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT4M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>3</Id>
+                            <Duration>PT27M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>ch:1:sloid:1008:4:7</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">7</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">7</Text>
+                                    </EstimatedQuay>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T06:42:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegAlight>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T07:09:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>2</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>highSpeedRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>9756</TrainNumber>
+                                    <siri:LineRef>ojp:9102E:Y</siri:LineRef>
+                                    <siri:OperatorRef>11</siri:OperatorRef>
+                                    <PublicCode>Train à grande vit.</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">TGV</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>20</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>H</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>ch:1:sloid:1008:4:7</OriginStopPointRef>
+                                    <DestinationStopPointRef>8774500</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ch:1:sjyid:100001:9756-001</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">VELOS: Keine Beförderung möglich</Text>
+                                        </UserText>
+                                        <Code>A__VN</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Minibar / Snack</Text>
+                                        </UserText>
+                                        <Code>A__MP</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung obligatorisch</Text>
+                                        </UserText>
+                                        <Code>A__RR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Globalpreis</Text>
+                                        </UserText>
+                                        <Code>A__GP</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Restaurant</Text>
+                                        </UserText>
+                                        <Code>A__WR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Aussteigeseite: Rechts</Text>
+                                        </UserText>
+                                        <Code>ojp9102EYH_InfoCall1_107019_1</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>4</Id>
+                            <Duration>PT3M</Duration>
+                            <TransferLeg>
+                                <TransferType>remainInVehicle</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT3M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>5</Id>
+                            <Duration>PT1H12M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T07:12:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegAlight>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T08:24:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>2</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>highSpeedRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>9756</TrainNumber>
+                                    <siri:LineRef>ojp:91632:A</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Train à grande vit.</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">632A</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>20</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>8774500</OriginStopPointRef>
+                                    <DestinationStopPointRef>8772319</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-632-A-j24-1-5-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Türen schliessen zwei Minuten vor Abfahrt</Text>
+                                        </UserText>
+                                        <Code>A__TA</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung obligatorisch</Text>
+                                        </UserText>
+                                        <Code>A__RR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Globalpreis</Text>
+                                        </UserText>
+                                        <Code>A__GP</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>6</Id>
+                            <Duration>PT10M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT10M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>7</Id>
+                            <Duration>PT1H15M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T09:06:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegAlight>
+                                    <siri:StopPointRef>8777500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Nîmes</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T10:21:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>2</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>highSpeedRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>5521</TrainNumber>
+                                    <siri:LineRef>ojp:9171B:_x0020_</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Train à grande vit.</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">071B</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>20</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>H</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>8772319</OriginStopPointRef>
+                                    <DestinationStopPointRef>8777500</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Nîmes</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-71B-_-j24-1-38-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Türen schliessen zwei Minuten vor Abfahrt</Text>
+                                        </UserText>
+                                        <Code>A__TA</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung obligatorisch</Text>
+                                        </UserText>
+                                        <Code>A__RR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Globalpreis</Text>
+                                        </UserText>
+                                        <Code>A__GP</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Deviation>true</Deviation>
+                    </Trip>
+                </TripResult>
+                <TripResult>
+                    <Id>ID-4EE2E13B-CAD1-4D22-8527-356C0C53674E</Id>
+                    <Trip>
+                        <Id>ID-4EE2E13B-CAD1-4D22-8527-356C0C53674E</Id>
+                        <Duration>PT6H28M</Duration>
+                        <StartTime>2024-07-03T05:05:00Z</StartTime>
+                        <EndTime>2024-07-03T11:33:00Z</EndTime>
+                        <Transfers>2</Transfers>
+                        <Leg>
+                            <Id>1</Id>
+                            <Duration>PT1H56M6S</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>ch:1:sloid:7000:2:3</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bern</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </EstimatedQuay>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T05:04:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T05:05:00Z</EstimatedTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:4100:1:1</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Fribourg/Freiburg</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">1</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">1</Text>
+                                    </EstimatedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T05:25:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T05:25:06Z</EstimatedTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T05:26:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T05:27:18Z</EstimatedTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:4023:1:1</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Romont FR</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">1</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">1</Text>
+                                    </EstimatedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T05:44:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T05:42:48Z</EstimatedTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T05:44:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T05:44:54Z</EstimatedTime>
+                                    </ServiceDeparture>
+                                    <Order>3</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:4014:1:1</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Palézieux</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">1</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">1</Text>
+                                    </EstimatedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T05:59:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T05:58:00Z</EstimatedTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T06:00:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T06:01:00Z</EstimatedTime>
+                                    </ServiceDeparture>
+                                    <Order>4</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:1120:0:860143</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Lausanne</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">4</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">7</Text>
+                                    </EstimatedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T06:16:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T06:15:36Z</EstimatedTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T06:19:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T06:20:36Z</EstimatedTime>
+                                    </ServiceDeparture>
+                                    <Order>5</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:1037:2:3</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Morges</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">2</Text>
+                                    </EstimatedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T06:29:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T06:30:54Z</EstimatedTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T06:29:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T06:33:00Z</EstimatedTime>
+                                    </ServiceDeparture>
+                                    <Order>6</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>ch:1:sloid:1030:1:1</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Nyon</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">1</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">1</Text>
+                                    </EstimatedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T06:45:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T06:46:42Z</EstimatedTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T06:46:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T06:48:48Z</EstimatedTime>
+                                    </ServiceDeparture>
+                                    <Order>7</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>ch:1:sloid:1008:2:3</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </StopPointName>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">3</Text>
+                                    </EstimatedQuay>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T07:01:00Z</TimetabledTime>
+                                        <EstimatedTime>2024-07-03T07:01:06Z</EstimatedTime>
+                                    </ServiceArrival>
+                                    <Order>8</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>regionalRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">IR</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>2508</TrainNumber>
+                                    <siri:LineRef>ojp:91015:B</siri:LineRef>
+                                    <siri:OperatorRef>11</siri:OperatorRef>
+                                    <PublicCode>InterRegio</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">IR15</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">IR</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>1</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>ch:1:sloid:7000:2:3</OriginStopPointRef>
+                                    <DestinationStopPointRef>ch:1:sloid:1008:2:3</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Bern</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ch:1:sjyid:100001:2508-003</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Businesszone in 1. Klasse</Text>
+                                        </UserText>
+                                        <Code>A__BZ</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Gratis-Internet mit der App SBB FreeSurf</Text>
+                                        </UserText>
+                                        <Code>A__FS</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Aussteigeseite: Rechts</Text>
+                                        </UserText>
+                                        <Code>ojp91015BR_InfoCall374_111055_1</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Aussteigeseite: Links</Text>
+                                        </UserText>
+                                        <Code>ojp91015BR_InfoCall374_107019_1</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>2</Id>
+                            <Duration>PT4M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8501008</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8501008</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT4M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>3</Id>
+                            <Duration>PT32M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>ch:1:sloid:1008:4:8</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </StopPointName>
+                                    <PlannedQuay>
+                                        <Text xml:lang="de">8</Text>
+                                    </PlannedQuay>
+                                    <EstimatedQuay>
+                                        <Text xml:lang="de">8</Text>
+                                    </EstimatedQuay>
+                                    <NameSuffix>
+                                        <Text xml:lang="de">NO_DATA</Text>
+                                    </NameSuffix>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T07:14:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegAlight>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T07:46:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>2</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>regionalRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TER</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>96558</TrainNumber>
+                                    <siri:LineRef>ojp:9101K:Y</siri:LineRef>
+                                    <siri:OperatorRef>11</siri:OperatorRef>
+                                    <PublicCode>Train Express Regional</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">TER</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TER</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>24</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>ch:1:sloid:1008:4:8</OriginStopPointRef>
+                                    <DestinationStopPointRef>8774500</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Genève</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ch:1:sjyid:100001:96558-002</JourneyRef>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>4</Id>
+                            <Duration>PT9M</Duration>
+                            <TransferLeg>
+                                <TransferType>remainInVehicle</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT9M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>5</Id>
+                            <Duration>PT1H27M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8774500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T07:55:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774582</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Seyssel-Corbonod</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T08:08:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T08:09:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774107</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Culoz</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T08:19:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T08:21:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>3</Order>
+                                </LegIntermediate>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8774375</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Tenay-Hauteville</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T08:42:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T08:44:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>4</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T09:22:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>5</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>regionalRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TER</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>96558</TrainNumber>
+                                    <siri:LineRef>ojp:91K1_x002B_:_x0020_</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Train Express Regional</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">K1+</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TER</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>24</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>H</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>8774500</OriginStopPointRef>
+                                    <DestinationStopPointRef>8772319</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Bellegarde-sur-Valserine</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-K1_x002B_-_-j24-1-19-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>6</Id>
+                            <Duration>PT10M</Duration>
+                            <TransferLeg>
+                                <TransferType>walk</TransferType>
+                                <LegStart>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </Name>
+                                </LegStart>
+                                <LegEnd>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <Name>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </Name>
+                                </LegEnd>
+                                <Duration>PT10M</Duration>
+                            </TransferLeg>
+                        </Leg>
+                        <Leg>
+                            <Id>7</Id>
+                            <Duration>PT1H23M</Duration>
+                            <TimedLeg>
+                                <LegBoard>
+                                    <siri:StopPointRef>8772319</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </StopPointName>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T10:10:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>1</Order>
+                                </LegBoard>
+                                <LegIntermediate>
+                                    <siri:StopPointRef>8776302</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Valence TGV Rhône-Alpes Sud</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T10:45:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <ServiceDeparture>
+                                        <TimetabledTime>2024-07-03T10:50:00Z</TimetabledTime>
+                                    </ServiceDeparture>
+                                    <Order>2</Order>
+                                </LegIntermediate>
+                                <LegAlight>
+                                    <siri:StopPointRef>8777500</siri:StopPointRef>
+                                    <StopPointName>
+                                        <Text xml:lang="de">Nîmes</Text>
+                                    </StopPointName>
+                                    <ServiceArrival>
+                                        <TimetabledTime>2024-07-03T11:33:00Z</TimetabledTime>
+                                    </ServiceArrival>
+                                    <Order>3</Order>
+                                </LegAlight>
+                                <Service>
+                                    <Mode>
+                                        <PtMode>rail</PtMode>
+                                        <siri:RailSubmode>highSpeedRail</siri:RailSubmode>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                    </Mode>
+                                    <ConventionalModeOfOperation>scheduled</ConventionalModeOfOperation>
+                                    <TrainNumber>6823</TrainNumber>
+                                    <siri:LineRef>ojp:9141G:_x0020_</siri:LineRef>
+                                    <siri:OperatorRef>87_LEX</siri:OperatorRef>
+                                    <PublicCode>Train à grande vit.</PublicCode>
+                                    <PublishedServiceName>
+                                        <Text xml:lang="de">041G</Text>
+                                    </PublishedServiceName>
+                                    <ProductCategory>
+                                        <Name>
+                                            <Text xml:lang="de">Zug</Text>
+                                        </Name>
+                                        <ShortName>
+                                            <Text xml:lang="de">TGV</Text>
+                                        </ShortName>
+                                        <ProductCategoryRef>20</ProductCategoryRef>
+                                    </ProductCategory>
+                                    <siri:DirectionRef>R</siri:DirectionRef>
+                                    <OperatingDayRef>2024-07-03</OperatingDayRef>
+                                    <OriginStopPointRef>8772319</OriginStopPointRef>
+                                    <DestinationStopPointRef>8777500</DestinationStopPointRef>
+                                    <OriginText>
+                                        <Text xml:lang="de">Lyon Part Dieu</Text>
+                                    </OriginText>
+                                    <DestinationText>
+                                        <Text xml:lang="de">Nîmes</Text>
+                                    </DestinationText>
+                                    <JourneyRef>ojp-91-41G-_-j24-1-65-TA</JourneyRef>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Türen schliessen zwei Minuten vor Abfahrt</Text>
+                                        </UserText>
+                                        <Code>A__TA</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Platzreservierung obligatorisch</Text>
+                                        </UserText>
+                                        <Code>A__RR</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Globalpreis</Text>
+                                        </UserText>
+                                        <Code>A__GP</Code>
+                                    </Attribute>
+                                    <Attribute>
+                                        <UserText>
+                                            <Text xml:lang="de">Niederflureinstieg</Text>
+                                        </UserText>
+                                        <Code>A__NF</Code>
+                                    </Attribute>
+                                </Service>
+                            </TimedLeg>
+                        </Leg>
+                        <Deviation>true</Deviation>
+                    </Trip>
+                </TripResult>
+            </OJPTripDelivery>
+        </siri:ServiceDelivery>
+    </OJPResponse>
+</OJP>

--- a/Tests/OJPTests/TripRequestTests.swift
+++ b/Tests/OJPTests/TripRequestTests.swift
@@ -130,7 +130,7 @@ final class TripRequestTests: XCTestCase {
     func testSituationParsing() async throws {
         let xmlData = try TestHelpers.loadXML(xmlFilename: "tr-berne-nimes")
         do {
-            guard case let .trip(tripDelivery) = try OJPDecoder.parseXML(xmlData).response?.serviceDelivery.delivery else {
+            guard case let .trip(tripDelivery) = try await OJPDecoder.parseXML(xmlData).response?.serviceDelivery.delivery else {
                 return XCTFail("unexpected empty")
             }
             guard let responseContext = tripDelivery.tripResponseContext else {

--- a/Tests/OJPTests/TripRequestTests.swift
+++ b/Tests/OJPTests/TripRequestTests.swift
@@ -123,4 +123,24 @@ final class TripRequestTests: XCTestCase {
 
         XCTAssertEqual(uniqued.count, 11)
     }
+
+
+    // MARK: - Situations (maybe move to separate file)
+
+    func testSituationParsing() async throws {
+        let xmlData = try TestHelpers.loadXML(xmlFilename: "tr-berne-nimes")
+        do {
+            guard case let .trip(tripDelivery) = try OJPDecoder.parseXML(xmlData).response?.serviceDelivery.delivery else {
+                return XCTFail("unexpected empty")
+            }
+            guard let responseContext = tripDelivery.tripResponseContext else {
+                return XCTFail("expected to have a tripResponseContext")
+            }
+            dump(responseContext)
+        } catch {
+            print(error)
+            throw error
+        }
+    }
+
 }


### PR DESCRIPTION
Solution for elements like "StartTime" that can be present in both OJP and SIRI namespace.

→ will create the mapping with taking in to account the whole coding path

Has a lower performance on big responses (eg. with track projection). maybe another strategy needs to be chosen.

⚠️ is based on #54 - so this should be merged first.