### PR TITLE
NearbyObject should conform to Sendable

### DIFF
--- a/Sources/OJP/Models/Geo.swift
+++ b/Sources/OJP/Models/Geo.swift
@@ -29,7 +29,7 @@ public struct Geo: Sendable {
     }
 }
 
-public struct NearbyObject<T: Sendable> {
+public struct NearbyObject<T: Sendable>: Sendable {
     public var object: T
     public var distance: Double
 }


### PR DESCRIPTION
Mark `NearbyObject` as `Sendable` to be compatible with Swift 6