### PR TITLE
Add option to allow count of loadNext/loadPrevious on PaginatedTripLoader

### DIFF
--- a/SampleApp/OJPSampleApp/Views/TripRequestView.swift
+++ b/SampleApp/OJPSampleApp/Views/TripRequestView.swift
@@ -19,6 +19,7 @@ struct TripRequestView: View {
     @State private var departureDateTime = Date.now
     @State var isLoading: Bool = false
     @State var paginatedActor: PaginatedTripLoader?
+    @State var pageSize: Int = 6
 
     var body: some View {
         VStack {
@@ -80,7 +81,7 @@ struct TripRequestView: View {
                                                     includeIntermediateStops: true,
                                                     useRealtimeData: .explanatory
                                                 )),
-                                    numberOfResults: .standard(6))
+                                    numberOfResults: .standard(pageSize))
                                 tripResults = tripDelivery.tripResults
                                 ptSituations = Set(tripDelivery.ptSituations)
                             } catch {
@@ -92,7 +93,14 @@ struct TripRequestView: View {
                     Text("Search")
                 }
             }
-            DatePicker("Departure", selection: $departureDateTime)
+            HStack(spacing: 20) {
+                DatePicker("", selection: $departureDateTime)
+                HStack {
+                    Text("Page Size")
+                    TextField("Page Size", value: $pageSize, formatter: NumberFormatter())
+                        .frame(maxWidth: 30)
+                }
+            }
             TripRequestResultView(
                 ptSituations: Array(ptSituations),
                 isLoading: isLoading,
@@ -102,7 +110,7 @@ struct TripRequestView: View {
                     isLoading = true
                     Task { @MainActor in
                         guard let paginatedActor else { return }
-                        let prev = try await paginatedActor.loadPrevious()
+                        let prev = try await paginatedActor.loadPrevious(pageSize)
                         tripResults = prev.tripResults + tripResults
                         ptSituations = ptSituations.union(prev.ptSituations)
                         isLoading = false
@@ -113,7 +121,7 @@ struct TripRequestView: View {
                     isLoading = true
                     Task { @MainActor in
                         guard let paginatedActor else { return }
-                        let next = try await paginatedActor.loadNext()
+                        let next = try await paginatedActor.loadNext(pageSize)
                         tripResults = tripResults + next.tripResults
                         ptSituations = ptSituations.union(next.ptSituations)
                         isLoading = false

--- a/Sources/OJP/Utilities/PaginatedTripLoader.swift
+++ b/Sources/OJP/Utilities/PaginatedTripLoader.swift
@@ -63,22 +63,24 @@ public actor PaginatedTripLoader {
 
     /// Based on the currently already loaded trip results, load the previous trips. Potential duplicates are filtered using  ``OJPv2/Trip/tripHash``.
     /// - Returns: new ``OJPv2/TripDelivery`` with ``OJPv2/NumberOfResults/before(_:)`` and the current lowest date as departure time.
-    public func loadPrevious() async throws -> OJPv2.TripDelivery {
+    public func loadPrevious(_ count: Int = 0) async throws -> OJPv2.TripDelivery {
         guard var request, let minDate else {
             throw OJPSDKError.notImplemented()
         }
+        let amount = count > 0 ? count : pageSize
         request.at = .departure(minDate)
-        return try await load(request: request, numberOfResults: .numbers(before: pageSize, after: 0))
+        return try await load(request: request, numberOfResults: .numbers(before: amount, after: 0))
     }
 
     /// Based on the currently already loaded trip results, load the future trips. Potential duplicates are filtered using  ``OJPv2/Trip/tripHash``.
     /// - Returns: new ``OJPv2/TripDelivery`` with ``OJPv2/NumberOfResults/after(_:)`` and the current highest date as departure time.
-    public func loadNext() async throws -> OJPv2.TripDelivery {
+    public func loadNext(_ count: Int = 0) async throws -> OJPv2.TripDelivery {
         guard var request, let maxDate else {
             throw OJPSDKError.notImplemented()
         }
         request.at = .departure(maxDate)
-        return try await load(request: request, numberOfResults: .numbers(before: 0, after: pageSize))
+        let amount = count > 0 ? count : pageSize
+        return try await load(request: request, numberOfResults: .numbers(before: 0, after: amount))
     }
 
     private func reset() {


### PR DESCRIPTION
In order to limit the amount of requested trips, a new param is added to `loadNext()` and `loadPrevious()`. If no value is added, the initial `pageSize` is taken into account.