### PR TITLE
ignore the destinationText of a leg until this is correctly returned …

### DIFF
--- a/Sources/OJP/Models/OJPv2+Trip.swift
+++ b/Sources/OJP/Models/OJPv2+Trip.swift
@@ -552,11 +552,11 @@ public extension OJPv2 {
                     h.combine(continuousLeg.legEnd)
                 case let .timed(timedLeg):
                     h.combine(timedLeg.service.publishedServiceName.text)
-                    h.combine(timedLeg.service.destinationText?.text)
-                    h.combine(timedLeg.legBoard.stopPointName.text)
+                    //h.combine(timedLeg.service.destinationText?.text)     // ignore this until this bug is fixed: https://github.com/openTdataCH/ojp-sdk/issues/198
+                    h.combine(timedLeg.legBoard.stopPointRef)
                     h.combine(timedLeg.legBoard.serviceDeparture.timetabledTime)
                     h.combine(timedLeg.legAlight.serviceArrival.timetabledTime)
-                    h.combine(timedLeg.legAlight.stopPointName.text)
+                    h.combine(timedLeg.legAlight.stopPointRef)
                     h.combine(timedLeg.service.trainNumber)
                 case let .transfer(transferLeg):
                     h.combine(transferLeg.transferTypes.hashValue)

--- a/Sources/OJP/Models/OJPv2+Trip.swift
+++ b/Sources/OJP/Models/OJPv2+Trip.swift
@@ -552,7 +552,7 @@ public extension OJPv2 {
                     h.combine(continuousLeg.legEnd)
                 case let .timed(timedLeg):
                     h.combine(timedLeg.service.publishedServiceName.text)
-                    //h.combine(timedLeg.service.destinationText?.text)     // ignore this until this bug is fixed: https://github.com/openTdataCH/ojp-sdk/issues/198
+                    h.combine(timedLeg.service.destinationStopPointRef)
                     h.combine(timedLeg.legBoard.stopPointRef)
                     h.combine(timedLeg.legBoard.serviceDeparture.timetabledTime)
                     h.combine(timedLeg.legAlight.serviceArrival.timetabledTime)


### PR DESCRIPTION
Currently the logic for fetching the next trip is not working correctly because the backend doesn't provide a consistent "destinationText" (this bug is still open https://github.com/openTdataCH/ojp-sdk/issues/198).

In the meantime we can fix this in the SDK and ignore the destinationText from the hash.
Also in order to have more robustness I think that is better to use the ids instead of the name for the leg stations.