### PR TITLE
use v1.0.1 of swift-duration

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,9 +3,9 @@
     {
       "identity" : "swift-duration",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/r3to/swift-duration.git",
+      "location" : "https://github.com/longinius/swift-duration.git",
       "state" : {
-        "revision" : "58b5127c26bff7264e53670c48702a932d6bd858",
+        "revision" : "7c1852d0e5756200ee1c7e9935cc00589a513654",
         "version" : "1.0.1"
       }
     },

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/CoreOffice/XMLCoder.git", from: "0.18.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4"),
-        .package(url: "https://github.com/r3to/swift-duration.git", from: "1.0.1"),
+        .package(url: "https://github.com/longinius/swift-duration.git", from: "1.0.1"),
         .package(url: "https://github.com/swiftlang/swift-testing.git", branch: "main")
     ],
     targets: [

--- a/SampleApp/OJPSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleApp/OJPSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -21,9 +21,9 @@
     {
       "identity" : "swift-duration",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/r3to/swift-duration.git",
+      "location" : "https://github.com/longinius/swift-duration.git",
       "state" : {
-        "revision" : "58b5127c26bff7264e53670c48702a932d6bd858",
+        "revision" : "7c1852d0e5756200ee1c7e9935cc00589a513654",
         "version" : "1.0.1"
       }
     },


### PR DESCRIPTION
0-second bug is fixed in swift duration, so we can switch back from the fork